### PR TITLE
Update GitHub actions for Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,12 +13,12 @@ jobs:
       matrix:
         node: ["22", "24"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with:
           key: g3ts
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node }}
           cache: npm

--- a/.plans/2026-05-18-105516-node24-actions.md
+++ b/.plans/2026-05-18-105516-node24-actions.md
@@ -1,0 +1,19 @@
+# Node 24 GitHub Actions Plan
+
+## Goal
+
+Remove GitHub's Node 20 action-runtime warning from CI by updating first-party actions to current Node 24-compatible major versions.
+
+## Approach
+
+- Update `.github/workflows/ci.yml`.
+- Change `actions/checkout@v4` to `actions/checkout@v6`.
+- Change `actions/setup-node@v4` to `actions/setup-node@v6`.
+- Run local validation.
+- Commit and push a PR branch.
+- Verify GitHub CI.
+
+## Files To Modify
+
+- `.github/workflows/ci.yml`
+- `.worklogs/2026-05-18-105516-node24-actions.md`

--- a/.worklogs/2026-05-18-105516-node24-actions.md
+++ b/.worklogs/2026-05-18-105516-node24-actions.md
@@ -1,0 +1,25 @@
+# Node 24 GitHub Actions
+
+## Summary
+
+Updated Slopless CI to use Node 24-compatible GitHub first-party actions.
+
+## Decisions Made
+
+- Changed `actions/checkout@v4` to `actions/checkout@v6`.
+- Changed `actions/setup-node@v4` to `actions/setup-node@v6`.
+- Left Rust and cache actions unchanged because the CI warning was produced by first-party JavaScript actions running on Node 20.
+
+## Key Files For Context
+
+- `.github/workflows/ci.yml`
+- `.plans/2026-05-18-105516-node24-actions.md`
+
+## Verification
+
+- `npm run validate`
+- GitHub PR CI
+
+## Next Steps
+
+- Merge after GitHub CI passes.


### PR DESCRIPTION
## Summary
- update checkout to v6
- update setup-node to v6
- remove Node 20 action-runtime warning

## Verification
- npm run validate
- git diff --check