### PR TITLE
Fix CLI version reporting

### DIFF
--- a/.plans/2026-05-19-155903-release-cli-version-fix.md
+++ b/.plans/2026-05-19-155903-release-cli-version-fix.md
@@ -1,0 +1,25 @@
+# Goal
+
+Release a corrected local and npm version after the local install exposed that `slopless@0.2.9` installs package version `0.2.9` but `slopless --version` prints `0.2.8`.
+
+# Approach
+
+- Fix `src/cli.ts` so the CLI version comes from `package.json` at runtime instead of a duplicated constant.
+- Add a verifier that fails when `dist/cli.js --version` differs from `package.json`.
+- Wire that verifier into `npm run validate` and `scripts/verify-all.sh`.
+- Bump the package to `0.2.10`, validate, commit, push, merge through CI, publish to npm, and install the new global package.
+
+# Key decisions
+
+- Do not republish `0.2.9`; npm published versions are immutable.
+- Do not keep a hardcoded CLI version; the package metadata is the single source of truth.
+- Keep the existing `resume` helper commit on the release branch because the user explicitly asked to commit it.
+
+# Files to modify
+
+- `src/cli.ts`
+- `package.json`
+- `package-lock.json`
+- `scripts/verify-cli-version.py`
+- `scripts/verify-all.sh`
+- `.worklogs/*`

--- a/.worklogs/2026-05-19-155649-commit-resume-helper.md
+++ b/.worklogs/2026-05-19-155649-commit-resume-helper.md
@@ -1,0 +1,21 @@
+# Summary
+
+Committed the repository-local Codex resume helper so the session can be restarted from this checkout. The helper stays outside the npm package because `package.json` only publishes `dist`, `README.md`, `skills`, and `slopless.textlintrc.json`.
+
+# Decisions Made
+
+- Kept the helper at the repo root as `resume`, matching the existing local file.
+- Marked it executable so it can be run directly.
+- Branched from `origin/main` because local `main` is stale and diverged.
+
+# Key Files For Context
+
+- `resume`
+
+# Verification
+
+- `git status --short`
+
+# Next Steps
+
+- Push the branch, open a PR to `main`, wait for CI, and merge.

--- a/.worklogs/2026-05-19-160029-release-cli-version-fix.md
+++ b/.worklogs/2026-05-19-160029-release-cli-version-fix.md
@@ -1,0 +1,26 @@
+# Summary
+
+Fixed the released CLI version drift found during local install verification. `slopless --version` now reads `package.json` instead of a stale hardcoded constant, and validation now fails if the CLI version differs from the package version.
+
+# Decisions made
+
+- Used `package.json` as the single source of truth for the CLI version.
+- Added `scripts/verify-cli-version.py` and wired it into `npm run validate` and `scripts/verify-all.sh`.
+- Bumped the package to `0.2.10` because `0.2.9` was already published and cannot be overwritten.
+
+# Key files for context
+
+- `src/cli.ts`
+- `package.json`
+- `package-lock.json`
+- `scripts/verify-cli-version.py`
+- `scripts/verify-all.sh`
+
+# Verification
+
+- `npm run validate`
+- `scripts/verify-all.sh`
+
+# Next steps
+
+- Push the branch, merge through CI, publish `slopless@0.2.10`, and install that version globally.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "slopless",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "slopless",
-      "version": "0.2.9",
+      "version": "0.2.10",
       "license": "MIT",
       "dependencies": {
         "@lunarisapp/readability": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "slopless",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "description": "Deterministic textlint rules for detecting slop in prose.",
   "license": "MIT",
   "repository": {
@@ -24,7 +24,7 @@
     "lint:css": "stylelint --max-warnings 0 \"styles/**/*.css\"",
     "spellcheck": "cspell .",
     "typecov": "type-coverage --strict --at-least 100",
-    "validate": "npm run build && npm run lint && npm run lint:css && prettier --check . && cspell . && type-coverage --strict --at-least 100 && scripts/validate-g3ts.sh"
+    "validate": "npm run build && scripts/verify-cli-version.py && npm run lint && npm run lint:css && prettier --check . && cspell . && type-coverage --strict --at-least 100 && scripts/validate-g3ts.sh"
   },
   "files": [
     "dist",

--- a/resume
+++ b/resume
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+exec codex resume \
+  019e1c9b-4630-7550-b32e-88d74af37345 \
+  -C "${repo_root}" \
+  --dangerously-bypass-approvals-and-sandbox

--- a/scripts/verify-all.sh
+++ b/scripts/verify-all.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT"
 
+scripts/verify-cli-version.py
 scripts/verify-source-material.py
 scripts/verify-dataset-source-reorganization.py
 scripts/verify-ai-slop-gaps.py

--- a/scripts/verify-cli-version.py
+++ b/scripts/verify-cli-version.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def main() -> int:
+    package_version = json.loads((ROOT / "package.json").read_text())["version"]
+    cli_version = subprocess.check_output(
+        ["node", str(ROOT / "dist" / "cli.js"), "--version"],
+        text=True,
+    ).strip()
+
+    if cli_version != package_version:
+        print("FAIL cli-version")
+        print(f"- package.json version: {package_version}")
+        print(f"- slopless --version: {cli_version}")
+        return 1
+
+    print("PASS cli-version")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,9 +1,14 @@
 #!/usr/bin/env node
 
+import { readFileSync } from "node:fs";
 import { cp, rm, stat } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { cli } from "textlint/lib/src/cli.js";
+
+type PackageMetadata = {
+  readonly version?: unknown;
+};
 
 type SkillTarget = "claude" | "codex";
 
@@ -28,7 +33,6 @@ const VALUE_OPTIONS = new Set([
   "-c",
   "-o"
 ]);
-const VERSION = "0.2.8";
 const HELP_TEXT = `Slopless checks English Markdown prose for deterministic AI and human slop signals.
 
 It reports concrete patterns that make writing padded, vague, generic,
@@ -170,6 +174,16 @@ function packageRoot(): string {
   return dirname(dirname(fileURLToPath(import.meta.url)));
 }
 
+function packageVersion(): string {
+  const packageJson = JSON.parse(
+    readFileSync(resolve(packageRoot(), "package.json"), "utf8")
+  ) as PackageMetadata;
+
+  return typeof packageJson.version === "string"
+    ? packageJson.version
+    : "0.0.0";
+}
+
 function packageNodeModules(): string {
   return resolve(packageRoot(), "..");
 }
@@ -231,7 +245,7 @@ async function main(): Promise<number> {
   }
 
   if (hasFlag(userArgs, VERSION_FLAGS)) {
-    process.stdout.write(`${VERSION}\n`);
+    process.stdout.write(`${packageVersion()}\n`);
     return 0;
   }
 


### PR DESCRIPTION
## Summary
- add the Codex resume helper requested for this repo
- make slopless --version read package.json instead of a stale constant
- add validation coverage for package version and CLI version drift
- bump package metadata to 0.2.10

## Verification
- npm run validate
- scripts/verify-all.sh