### PR TITLE
Release slopless 0.2.12

### DIFF
--- a/.worklogs/2026-05-21-152527-release-0-2-12.md
+++ b/.worklogs/2026-05-21-152527-release-0-2-12.md
@@ -1,0 +1,27 @@
+# Release 0.2.12
+
+## Summary
+
+Prepared the patch release for the dependency unification that landed in PR #44. This release publishes the coherent textlint 15.7, ESLint 10, TypeScript 6, and Node 22 type-support update.
+
+## Decisions Made
+
+- Bumped from `0.2.11` to `0.2.12` because the npm registry still had `0.2.11` and `main` now contains package changes.
+- Kept this as a patch release because the public CLI and rule behavior are unchanged; the release updates dependency compatibility and build tooling.
+
+## Key Files For Context
+
+- `package.json`
+- `pnpm-lock.yaml`
+- `.worklogs/2026-05-21-152527-release-0-2-12.md`
+
+## Verification
+
+- Pending in this release turn: `pnpm install --frozen-lockfile`
+- Pending in this release turn: `pnpm run validate`
+- Pending in this release turn: `npm publish --access public`
+
+## Next Steps
+
+- Publish `slopless@0.2.12`.
+- Verify fresh install from npm.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "slopless",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "description": "Deterministic textlint rules for detecting slop in prose.",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary
- bump package version to 0.2.12 after dependency unification landed in #44
- add release worklog

## Verification
- pnpm install --frozen-lockfile
- pnpm run validate