### PR TITLE
Release slopless 0.2.13

### DIFF
--- a/.worklogs/2026-05-23-185052-release-0-2-13.md
+++ b/.worklogs/2026-05-23-185052-release-0-2-13.md
@@ -1,0 +1,16 @@
+# Release slopless 0.2.13
+
+## Summary
+
+Bump version 0.2.12 → 0.2.13. First release through the new OIDC Trusted Publishing workflow (PR #46). No source changes since 0.2.12; this release validates the new publish pipeline (provenance attestation, no NPM_TOKEN).
+
+## Procedure (new vs old)
+
+1. Merge this PR.
+2. Create the GitHub Release with `gh release create v0.2.13 --generate-notes --target main`. That publish event triggers `.github/workflows/release.yml`, which builds, verifies the tag matches `package.json` version, and runs `pnpm publish --provenance --access public --no-git-checks`. Auth is via OIDC; no token configured.
+3. Confirm the green "Provenance" panel on https://www.npmjs.com/package/slopless.
+4. `npm audit signatures slopless` from any clean directory to verify the attestation.
+
+## Fallback if publish 403s
+
+The Trusted Publisher binding on npmjs.com is the most likely failure point. Recheck at https://www.npmjs.com/package/slopless/access: organization `seochecks-ai`, repository `slopless`, workflow filename `release.yml`, environment blank, allowed actions include `npm publish`. All fields are case-sensitive.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "slopless",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "description": "Deterministic textlint rules and CLI for catching prose slop in English Markdown.",
   "keywords": [
     "textlint",


### PR DESCRIPTION
## Summary

First release through the OIDC Trusted Publishing workflow added in #46. No source changes since 0.2.12; this release validates the new publish pipeline end-to-end (provenance attestation, no NPM_TOKEN secret).

## Test plan

- [ ] CI green.
- [ ] Merge.
- [ ] `gh release create v0.2.13 --generate-notes --target main` triggers `Release` workflow.
- [ ] Workflow publishes via OIDC, emits provenance attestation.
- [ ] `https://www.npmjs.com/package/slopless` shows green Provenance panel.
- [ ] `npm view slopless@0.2.13 dist.attestations` returns the attestation.

Generated with [Claude Code](https://claude.com/claude-code)