### PR TITLE
Release slopless 0.2.14

### DIFF
--- a/.worklogs/2026-05-23-194546-release-0-2-14.md
+++ b/.worklogs/2026-05-23-194546-release-0-2-14.md
@@ -1,0 +1,18 @@
+# Release slopless 0.2.14
+
+## Summary
+
+Ships the bundle-size kill (PR #48). Expected impact on the npm/bundlephobia pages:
+
+- Tarball: ~110 KB (was 165 KB at 0.2.12)
+- Install footprint: ~180 KB (was ~21 MB)
+- Bundle: ~50 KB raw / ~16 KB gzip (was 10.6 MB / 2.98 MB gzip)
+
+Score behavior for `flesch-kincaid` and `gunning-fog` shifts slightly (different syllable counter) but the existing thresholds still fire on the same inputs. Coleman-Liau is essentially identical. See PR #48 for details.
+
+## Procedure
+
+1. Merge this PR.
+2. `gh release create v0.2.14 --generate-notes --target main`. OIDC publish kicks in.
+3. Confirm npm page shows new size + green Provenance panel.
+4. Verify via bundlephobia + packagephobia after CDN refresh (~5 min).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "slopless",
-  "version": "0.2.13",
+  "version": "0.2.14",
   "description": "Deterministic textlint rules and CLI for catching prose slop in English Markdown.",
   "keywords": [
     "textlint",


### PR DESCRIPTION
## Summary

Ships the bundle-size kill from #48. Replaces `@lunarisapp/readability` (21 MB on disk, 2.98 MB gzip bundle) with `text-readability` (180 KB on disk, ~16 KB gzip bundle).

## Test plan

- [ ] CI green
- [ ] Merge
- [ ] `gh release create v0.2.14 --generate-notes --target main` triggers OIDC publish
- [ ] npm page (https://www.npmjs.com/package/slopless) shows reduced size + Provenance panel
- [ ] bundlephobia + packagephobia reflect the drop

Generated with [Claude Code](https://claude.com/claude-code)