### PR TITLE
Make simplicity and llm-vocabulary density-based; release 0.2.16

### DIFF
--- a/.worklogs/2026-06-01-172644-density-simplicity-llm-vocabulary.md
+++ b/.worklogs/2026-06-01-172644-density-simplicity-llm-vocabulary.md
@@ -1,0 +1,42 @@
+# simplicity + llm-vocabulary made density-based (release 0.2.16)
+
+## Summary
+
+Residual precision work from the false-positive audit: the per-instance `simplicity` and `llm-vocabulary`
+rules over-fired on ordinary single words in human prose (1,723 and 765 false positives in the audit). Both
+now fire only when stock/complex diction clusters, mirroring the existing `llm-vocabulary-density` rule.
+
+## Decisions
+
+- `src/rules/words/simplicity.ts`: converted from `oneToOneRule` to a `density` report policy over its 5
+  complex words (utilize, implement, facilitate, numerous, commence). `MIN_HITS = 2` (a 5-word vocabulary, so
+  two clustered is the meaningful "complex diction is piling up" signal). Loses the per-word "use X instead"
+  suggestion in favor of a density message.
+- `src/rules/words/llm-vocabulary.ts`: converted to a `density` report policy over its 12 stock words, with
+  the existing `isVocabularyContextAllowed` gate. `MIN_HITS = 3`. Words that are slop on their own (e.g.
+  "delve") are still caught per-instance by `prohibited-words`, so single-word coverage of those is unchanged.
+
+## Verification
+
+- 100 Wikipedia files: both rules now fire 0 (were hundreds of per-instance hits).
+- Fires correctly on clusters: "utilize numerous ... facilitate" -> simplicity; a 3+ stock-word span ->
+  llm-vocabulary. Does not fire on a single "numerous" or "comprehensive".
+- AI marketing clustering is still caught by `llm-vocabulary-density`.
+- Fixtures: cases/words/hits.md already contained density clusters (lines 29 and 31) that fire under the new
+  rules, so positive coverage is preserved; the removed hits were single-word demos.
+- Goldens re-approved for the 5 suites whose only drift was `simplicity`/`llm-vocabulary` (per-instance hits
+  removed, density hits retained). No other rule changed. `fixture3 check --all` matches on all 19 suites.
+- eslint, prettier, cspell, type-coverage 100%, build all pass.
+
+## Key files
+
+- `src/rules/words/simplicity.ts`, `src/rules/words/llm-vocabulary.ts`
+- Reference pattern: `src/rules/words/llm-vocabulary-density.ts`
+
+## Next steps
+
+- Remaining audit residuals (separate, not yet done): negation-reframe pair path + block-overcapture bug;
+  narrative rules firing on non-narrative text; fragment-stacking on reference lists; softening/hedge-stacking;
+  prohibited-words list trim.
+- Consider consolidating `llm-vocabulary` into `llm-vocabulary-density` (two density rules now overlap).
+- Recompute the human-vs-AI gap on the cleaned rule set for the article.

--- a/behavior/golden/textlint-rules-cases-academic-slop/approved.meta.json
+++ b/behavior/golden/textlint-rules-cases-academic-slop/approved.meta.json
@@ -1,10 +1,10 @@
 {
   "suite": "textlint-rules-cases-academic-slop",
   "kind": "approved",
-  "run_id": "2026-05-23T18-36-39.367015Z-04547efb",
-  "run_commit": "ece876d",
+  "run_id": "2026-06-01T16-23-08.547317Z-04547efb",
+  "run_commit": "208fd3d",
   "working_tree": "dirty",
-  "recorded_at": "2026-05-23T18:36:39.367015Z",
+  "recorded_at": "2026-06-01T16:23:08.547317Z",
   "fixture_hash": "sha256:21c9eb15ab55b9374a75b701376d20d94e451a6650463fd8869b6637b425da9a",
   "manifest_hash": "sha256:04547efbb13157ee3d8ef18dda767231fd63d3f9cc27c15317cf28c5f0583e7b",
   "tool_version": "0.1.8",
@@ -19,5 +19,5 @@
       "sha256": "sha256:6543887eb8d2e848d692884bd82ab53b601cb41afea1a5ab79611bcb6a2c453d"
     }
   ],
-  "comment": "text-readability swap: syllable-based metric scores shift slightly vs @lunarisapp; same direction"
+  "comment": "simplicity + llm-vocabulary now density-based: removes per-instance single-word false positives; density cluster hits retained"
 }

--- a/behavior/golden/textlint-rules-cases-academic-slop/approved.normalized.json
+++ b/behavior/golden/textlint-rules-cases-academic-slop/approved.normalized.json
@@ -394,29 +394,6 @@
         "type": "lint"
       },
       {
-        "column": 24,
-        "index": 1089,
-        "line": 25,
-        "loc": {
-          "end": {
-            "column": 37,
-            "line": 25
-          },
-          "start": {
-            "column": 24,
-            "line": 25
-          }
-        },
-        "message": "LLM vocabulary found: \"comprehensive\". Replace the stock diction with a concrete word.",
-        "range": [
-          1089,
-          1102
-        ],
-        "ruleId": "llm-vocabulary",
-        "severity": 2,
-        "type": "lint"
-      },
-      {
         "column": 1,
         "index": 1176,
         "line": 27,
@@ -597,29 +574,6 @@
           1833
         ],
         "ruleId": "academic-boilerplate",
-        "severity": 2,
-        "type": "lint"
-      },
-      {
-        "column": 26,
-        "index": 1861,
-        "line": 39,
-        "loc": {
-          "end": {
-            "column": 34,
-            "line": 39
-          },
-          "start": {
-            "column": 26,
-            "line": 39
-          }
-        },
-        "message": "LLM vocabulary found: \"tapestry\". Replace the stock diction with a concrete word.",
-        "range": [
-          1861,
-          1869
-        ],
-        "ruleId": "llm-vocabulary",
         "severity": 2,
         "type": "lint"
       },

--- a/behavior/golden/textlint-rules-cases-syntactic-patterns/approved.meta.json
+++ b/behavior/golden/textlint-rules-cases-syntactic-patterns/approved.meta.json
@@ -1,10 +1,10 @@
 {
   "suite": "textlint-rules-cases-syntactic-patterns",
   "kind": "approved",
-  "run_id": "2026-06-01T15-47-09.653897Z-04547efb",
-  "run_commit": "2f16376",
+  "run_id": "2026-06-01T16-23-37.269833Z-04547efb",
+  "run_commit": "208fd3d",
   "working_tree": "dirty",
-  "recorded_at": "2026-06-01T15:47:09.653897Z",
+  "recorded_at": "2026-06-01T16:23:37.269833Z",
   "fixture_hash": "sha256:6bd124742509d23b75dd2fef3e2dcd7269a0a82e8e748268dbcd00f968bdc43a",
   "manifest_hash": "sha256:04547efbb13157ee3d8ef18dda767231fd63d3f9cc27c15317cf28c5f0583e7b",
   "tool_version": "0.1.8",
@@ -19,5 +19,5 @@
       "sha256": "sha256:db16ee9450ad63bdb12478d918b92df8d4b2f7103e6556f2c982b26a50c895e1"
     }
   ],
-  "comment": "triple-repeat precision: gate bare openers to non-stop-words and skip empty opener; removes common-opener false positives (the/it/she/they/...)"
+  "comment": "simplicity + llm-vocabulary now density-based: removes per-instance single-word false positives; density cluster hits retained"
 }

--- a/behavior/golden/textlint-rules-cases-syntactic-patterns/approved.normalized.json
+++ b/behavior/golden/textlint-rules-cases-syntactic-patterns/approved.normalized.json
@@ -10734,29 +10734,6 @@
             "line": 943
           }
         },
-        "message": "LLM vocabulary found: \"delve\". Replace the stock diction with a concrete word.",
-        "range": [
-          45607,
-          45612
-        ],
-        "ruleId": "llm-vocabulary",
-        "severity": 2,
-        "type": "lint"
-      },
-      {
-        "column": 7,
-        "index": 45607,
-        "line": 943,
-        "loc": {
-          "end": {
-            "column": 12,
-            "line": 943
-          },
-          "start": {
-            "column": 7,
-            "line": 943
-          }
-        },
         "message": "Prohibited word found: \"delve\". Rewrite without this term.",
         "range": [
           45607,
@@ -10786,29 +10763,6 @@
           45700
         ],
         "ruleId": "response-wrapper",
-        "severity": 2,
-        "type": "lint"
-      },
-      {
-        "column": 13,
-        "index": 45675,
-        "line": 945,
-        "loc": {
-          "end": {
-            "column": 18,
-            "line": 945
-          },
-          "start": {
-            "column": 13,
-            "line": 945
-          }
-        },
-        "message": "LLM vocabulary found: \"delve\". Replace the stock diction with a concrete word.",
-        "range": [
-          45675,
-          45680
-        ],
-        "ruleId": "llm-vocabulary",
         "severity": 2,
         "type": "lint"
       },
@@ -11016,29 +10970,6 @@
           46053
         ],
         "ruleId": "response-wrapper",
-        "severity": 2,
-        "type": "lint"
-      },
-      {
-        "column": 27,
-        "index": 46017,
-        "line": 959,
-        "loc": {
-          "end": {
-            "column": 32,
-            "line": 959
-          },
-          "start": {
-            "column": 27,
-            "line": 959
-          }
-        },
-        "message": "LLM vocabulary found: \"delve\". Replace the stock diction with a concrete word.",
-        "range": [
-          46017,
-          46022
-        ],
-        "ruleId": "llm-vocabulary",
         "severity": 2,
         "type": "lint"
       },

--- a/behavior/golden/textlint-rules-cases-words/approved.meta.json
+++ b/behavior/golden/textlint-rules-cases-words/approved.meta.json
@@ -1,10 +1,10 @@
 {
   "suite": "textlint-rules-cases-words",
   "kind": "approved",
-  "run_id": "2026-05-23T18-37-11.894689Z-04547efb",
-  "run_commit": "ece876d",
+  "run_id": "2026-06-01T16-23-41.544962Z-04547efb",
+  "run_commit": "208fd3d",
   "working_tree": "dirty",
-  "recorded_at": "2026-05-23T18:37:11.894689Z",
+  "recorded_at": "2026-06-01T16:23:41.544962Z",
   "fixture_hash": "sha256:21a1a39902413e258c573622d03efa5ff8c7ffb7da029b25b39dc0fa03767d72",
   "manifest_hash": "sha256:04547efbb13157ee3d8ef18dda767231fd63d3f9cc27c15317cf28c5f0583e7b",
   "tool_version": "0.1.8",
@@ -19,5 +19,5 @@
       "sha256": "sha256:d348fdcaf4647ffa8b1bf6e0643cdc904dfa957cb47077f98416639440874417"
     }
   ],
-  "comment": "text-readability swap: syllable-based metric scores shift slightly vs @lunarisapp; same direction"
+  "comment": "simplicity + llm-vocabulary now density-based: removes per-instance single-word false positives; density cluster hits retained"
 }

--- a/behavior/golden/textlint-rules-cases-words/approved.normalized.json
+++ b/behavior/golden/textlint-rules-cases-words/approved.normalized.json
@@ -118,29 +118,6 @@
         "type": "lint"
       },
       {
-        "column": 36,
-        "index": 194,
-        "line": 7,
-        "loc": {
-          "end": {
-            "column": 43,
-            "line": 7
-          },
-          "start": {
-            "column": 36,
-            "line": 7
-          }
-        },
-        "message": "LLM vocabulary found: \"pivotal\". Replace the stock diction with a concrete word.",
-        "range": [
-          194,
-          201
-        ],
-        "ruleId": "llm-vocabulary",
-        "severity": 2,
-        "type": "lint"
-      },
-      {
         "column": 22,
         "index": 336,
         "line": 13,
@@ -187,75 +164,6 @@
         "type": "lint"
       },
       {
-        "column": 26,
-        "index": 446,
-        "line": 17,
-        "loc": {
-          "end": {
-            "column": 33,
-            "line": 17
-          },
-          "start": {
-            "column": 26,
-            "line": 17
-          }
-        },
-        "message": "Complex word found: \"utilize\". Use \"use\" instead.",
-        "range": [
-          446,
-          453
-        ],
-        "ruleId": "simplicity",
-        "severity": 2,
-        "type": "lint"
-      },
-      {
-        "column": 22,
-        "index": 493,
-        "line": 19,
-        "loc": {
-          "end": {
-            "column": 32,
-            "line": 19
-          },
-          "start": {
-            "column": 22,
-            "line": 19
-          }
-        },
-        "message": "Complex word found: \"FACILITATE\". Use \"help\" instead.",
-        "range": [
-          493,
-          503
-        ],
-        "ruleId": "simplicity",
-        "severity": 2,
-        "type": "lint"
-      },
-      {
-        "column": 39,
-        "index": 610,
-        "line": 23,
-        "loc": {
-          "end": {
-            "column": 44,
-            "line": 23
-          },
-          "start": {
-            "column": 39,
-            "line": 23
-          }
-        },
-        "message": "LLM vocabulary found: \"realm\". Replace the stock diction with a concrete word.",
-        "range": [
-          610,
-          615
-        ],
-        "ruleId": "llm-vocabulary",
-        "severity": 2,
-        "type": "lint"
-      },
-      {
         "column": 39,
         "index": 610,
         "line": 23,
@@ -275,29 +183,6 @@
           615
         ],
         "ruleId": "prohibited-words",
-        "severity": 2,
-        "type": "lint"
-      },
-      {
-        "column": 29,
-        "index": 661,
-        "line": 25,
-        "loc": {
-          "end": {
-            "column": 36,
-            "line": 25
-          },
-          "start": {
-            "column": 29,
-            "line": 25
-          }
-        },
-        "message": "Complex word found: \"utilize\". Use \"use\" instead.",
-        "range": [
-          661,
-          668
-        ],
-        "ruleId": "simplicity",
         "severity": 2,
         "type": "lint"
       },
@@ -399,7 +284,7 @@
         "line": 29,
         "loc": {
           "end": {
-            "column": 25,
+            "column": 54,
             "line": 29
           },
           "start": {
@@ -407,55 +292,9 @@
             "line": 29
           }
         },
-        "message": "Complex word found: \"utilize\". Use \"use\" instead.",
+        "message": "Complex word density: 3 complex words in a short span (utilize, numerous, facilitate). Prefer simpler wording.",
         "range": [
           779,
-          786
-        ],
-        "ruleId": "simplicity",
-        "severity": 2,
-        "type": "lint"
-      },
-      {
-        "column": 26,
-        "index": 787,
-        "line": 29,
-        "loc": {
-          "end": {
-            "column": 34,
-            "line": 29
-          },
-          "start": {
-            "column": 26,
-            "line": 29
-          }
-        },
-        "message": "Complex word found: \"numerous\". Use \"many\" instead.",
-        "range": [
-          787,
-          795
-        ],
-        "ruleId": "simplicity",
-        "severity": 2,
-        "type": "lint"
-      },
-      {
-        "column": 44,
-        "index": 805,
-        "line": 29,
-        "loc": {
-          "end": {
-            "column": 54,
-            "line": 29
-          },
-          "start": {
-            "column": 44,
-            "line": 29
-          }
-        },
-        "message": "Complex word found: \"facilitate\". Use \"help\" instead.",
-        "range": [
-          805,
           815
         ],
         "ruleId": "simplicity",
@@ -468,7 +307,7 @@
         "line": 31,
         "loc": {
           "end": {
-            "column": 13,
+            "column": 75,
             "line": 31
           },
           "start": {
@@ -476,56 +315,10 @@
             "line": 31
           }
         },
-        "message": "LLM vocabulary found: \"vibrant\". Replace the stock diction with a concrete word.",
+        "message": "LLM vocabulary density: 5 stock words in a short span (vibrant, landscape, delve, intricate, tapestry). Replace the stock diction with concrete words.",
         "range": [
           834,
-          841
-        ],
-        "ruleId": "llm-vocabulary",
-        "severity": 2,
-        "type": "lint"
-      },
-      {
-        "column": 14,
-        "index": 842,
-        "line": 31,
-        "loc": {
-          "end": {
-            "column": 23,
-            "line": 31
-          },
-          "start": {
-            "column": 14,
-            "line": 31
-          }
-        },
-        "message": "LLM vocabulary found: \"landscape\". Replace the stock diction with a concrete word.",
-        "range": [
-          842,
-          851
-        ],
-        "ruleId": "llm-vocabulary",
-        "severity": 2,
-        "type": "lint"
-      },
-      {
-        "column": 43,
-        "index": 871,
-        "line": 31,
-        "loc": {
-          "end": {
-            "column": 48,
-            "line": 31
-          },
-          "start": {
-            "column": 43,
-            "line": 31
-          }
-        },
-        "message": "LLM vocabulary found: \"delve\". Replace the stock diction with a concrete word.",
-        "range": [
-          871,
-          876
+          903
         ],
         "ruleId": "llm-vocabulary",
         "severity": 2,
@@ -555,52 +348,6 @@
         "type": "lint"
       },
       {
-        "column": 57,
-        "index": 885,
-        "line": 31,
-        "loc": {
-          "end": {
-            "column": 66,
-            "line": 31
-          },
-          "start": {
-            "column": 57,
-            "line": 31
-          }
-        },
-        "message": "LLM vocabulary found: \"intricate\". Replace the stock diction with a concrete word.",
-        "range": [
-          885,
-          894
-        ],
-        "ruleId": "llm-vocabulary",
-        "severity": 2,
-        "type": "lint"
-      },
-      {
-        "column": 67,
-        "index": 895,
-        "line": 31,
-        "loc": {
-          "end": {
-            "column": 75,
-            "line": 31
-          },
-          "start": {
-            "column": 67,
-            "line": 31
-          }
-        },
-        "message": "LLM vocabulary found: \"tapestry\". Replace the stock diction with a concrete word.",
-        "range": [
-          895,
-          903
-        ],
-        "ruleId": "llm-vocabulary",
-        "severity": 2,
-        "type": "lint"
-      },
-      {
         "column": 67,
         "index": 895,
         "line": 31,
@@ -620,29 +367,6 @@
           903
         ],
         "ruleId": "prohibited-words",
-        "severity": 2,
-        "type": "lint"
-      },
-      {
-        "column": 1,
-        "index": 906,
-        "line": 33,
-        "loc": {
-          "end": {
-            "column": 9,
-            "line": 33
-          },
-          "start": {
-            "column": 1,
-            "line": 33
-          }
-        },
-        "message": "LLM vocabulary found: \"Moreover\". Replace the stock diction with a concrete word.",
-        "range": [
-          906,
-          914
-        ],
-        "ruleId": "llm-vocabulary",
         "severity": 2,
         "type": "lint"
       },

--- a/behavior/golden/textlint-rules-corpus-editorial-style/approved.meta.json
+++ b/behavior/golden/textlint-rules-corpus-editorial-style/approved.meta.json
@@ -1,10 +1,10 @@
 {
   "suite": "textlint-rules-corpus-editorial-style",
   "kind": "approved",
-  "run_id": "2026-06-01T15-47-21.959061Z-04547efb",
-  "run_commit": "2f16376",
+  "run_id": "2026-06-01T16-23-49.231661Z-04547efb",
+  "run_commit": "208fd3d",
   "working_tree": "dirty",
-  "recorded_at": "2026-06-01T15:47:21.959061Z",
+  "recorded_at": "2026-06-01T16:23:49.231661Z",
   "fixture_hash": "sha256:4bd5003519fd18ea8f658c8a6924de410406ad2f07b663c4a38887ec5703dd41",
   "manifest_hash": "sha256:04547efbb13157ee3d8ef18dda767231fd63d3f9cc27c15317cf28c5f0583e7b",
   "tool_version": "0.1.8",
@@ -15,5 +15,5 @@
       "sha256": "sha256:b301820ddd2a34b66a08414171ee10cdbd8e476d78de00cdeb4c01a7abf80394"
     }
   ],
-  "comment": "triple-repeat precision: gate bare openers to non-stop-words and skip empty opener; removes common-opener false positives (the/it/she/they/...)"
+  "comment": "simplicity + llm-vocabulary now density-based: removes per-instance single-word false positives; density cluster hits retained"
 }

--- a/behavior/golden/textlint-rules-corpus-editorial-style/approved.normalized.json
+++ b/behavior/golden/textlint-rules-corpus-editorial-style/approved.normalized.json
@@ -1751,29 +1751,6 @@
         "type": "lint"
       },
       {
-        "column": 36,
-        "index": 7672,
-        "line": 245,
-        "loc": {
-          "end": {
-            "column": 43,
-            "line": 245
-          },
-          "start": {
-            "column": 36,
-            "line": 245
-          }
-        },
-        "message": "LLM vocabulary found: \"pivotal\". Replace the stock diction with a concrete word.",
-        "range": [
-          7672,
-          7679
-        ],
-        "ruleId": "llm-vocabulary",
-        "severity": 2,
-        "type": "lint"
-      },
-      {
         "column": 22,
         "index": 7814,
         "line": 251,
@@ -1820,75 +1797,6 @@
         "type": "lint"
       },
       {
-        "column": 26,
-        "index": 7924,
-        "line": 255,
-        "loc": {
-          "end": {
-            "column": 33,
-            "line": 255
-          },
-          "start": {
-            "column": 26,
-            "line": 255
-          }
-        },
-        "message": "Complex word found: \"utilize\". Use \"use\" instead.",
-        "range": [
-          7924,
-          7931
-        ],
-        "ruleId": "simplicity",
-        "severity": 2,
-        "type": "lint"
-      },
-      {
-        "column": 22,
-        "index": 7971,
-        "line": 257,
-        "loc": {
-          "end": {
-            "column": 32,
-            "line": 257
-          },
-          "start": {
-            "column": 22,
-            "line": 257
-          }
-        },
-        "message": "Complex word found: \"FACILITATE\". Use \"help\" instead.",
-        "range": [
-          7971,
-          7981
-        ],
-        "ruleId": "simplicity",
-        "severity": 2,
-        "type": "lint"
-      },
-      {
-        "column": 39,
-        "index": 8088,
-        "line": 261,
-        "loc": {
-          "end": {
-            "column": 44,
-            "line": 261
-          },
-          "start": {
-            "column": 39,
-            "line": 261
-          }
-        },
-        "message": "LLM vocabulary found: \"realm\". Replace the stock diction with a concrete word.",
-        "range": [
-          8088,
-          8093
-        ],
-        "ruleId": "llm-vocabulary",
-        "severity": 2,
-        "type": "lint"
-      },
-      {
         "column": 39,
         "index": 8088,
         "line": 261,
@@ -1908,29 +1816,6 @@
           8093
         ],
         "ruleId": "prohibited-words",
-        "severity": 2,
-        "type": "lint"
-      },
-      {
-        "column": 29,
-        "index": 8139,
-        "line": 263,
-        "loc": {
-          "end": {
-            "column": 36,
-            "line": 263
-          },
-          "start": {
-            "column": 29,
-            "line": 263
-          }
-        },
-        "message": "Complex word found: \"utilize\". Use \"use\" instead.",
-        "range": [
-          8139,
-          8146
-        ],
-        "ruleId": "simplicity",
         "severity": 2,
         "type": "lint"
       },
@@ -2032,7 +1917,7 @@
         "line": 267,
         "loc": {
           "end": {
-            "column": 25,
+            "column": 54,
             "line": 267
           },
           "start": {
@@ -2040,55 +1925,9 @@
             "line": 267
           }
         },
-        "message": "Complex word found: \"utilize\". Use \"use\" instead.",
+        "message": "Complex word density: 3 complex words in a short span (utilize, numerous, facilitate). Prefer simpler wording.",
         "range": [
           8257,
-          8264
-        ],
-        "ruleId": "simplicity",
-        "severity": 2,
-        "type": "lint"
-      },
-      {
-        "column": 26,
-        "index": 8265,
-        "line": 267,
-        "loc": {
-          "end": {
-            "column": 34,
-            "line": 267
-          },
-          "start": {
-            "column": 26,
-            "line": 267
-          }
-        },
-        "message": "Complex word found: \"numerous\". Use \"many\" instead.",
-        "range": [
-          8265,
-          8273
-        ],
-        "ruleId": "simplicity",
-        "severity": 2,
-        "type": "lint"
-      },
-      {
-        "column": 44,
-        "index": 8283,
-        "line": 267,
-        "loc": {
-          "end": {
-            "column": 54,
-            "line": 267
-          },
-          "start": {
-            "column": 44,
-            "line": 267
-          }
-        },
-        "message": "Complex word found: \"facilitate\". Use \"help\" instead.",
-        "range": [
-          8283,
           8293
         ],
         "ruleId": "simplicity",
@@ -2101,7 +1940,7 @@
         "line": 269,
         "loc": {
           "end": {
-            "column": 13,
+            "column": 75,
             "line": 269
           },
           "start": {
@@ -2109,56 +1948,10 @@
             "line": 269
           }
         },
-        "message": "LLM vocabulary found: \"vibrant\". Replace the stock diction with a concrete word.",
+        "message": "LLM vocabulary density: 5 stock words in a short span (vibrant, landscape, delve, intricate, tapestry). Replace the stock diction with concrete words.",
         "range": [
           8312,
-          8319
-        ],
-        "ruleId": "llm-vocabulary",
-        "severity": 2,
-        "type": "lint"
-      },
-      {
-        "column": 14,
-        "index": 8320,
-        "line": 269,
-        "loc": {
-          "end": {
-            "column": 23,
-            "line": 269
-          },
-          "start": {
-            "column": 14,
-            "line": 269
-          }
-        },
-        "message": "LLM vocabulary found: \"landscape\". Replace the stock diction with a concrete word.",
-        "range": [
-          8320,
-          8329
-        ],
-        "ruleId": "llm-vocabulary",
-        "severity": 2,
-        "type": "lint"
-      },
-      {
-        "column": 43,
-        "index": 8349,
-        "line": 269,
-        "loc": {
-          "end": {
-            "column": 48,
-            "line": 269
-          },
-          "start": {
-            "column": 43,
-            "line": 269
-          }
-        },
-        "message": "LLM vocabulary found: \"delve\". Replace the stock diction with a concrete word.",
-        "range": [
-          8349,
-          8354
+          8381
         ],
         "ruleId": "llm-vocabulary",
         "severity": 2,
@@ -2188,52 +1981,6 @@
         "type": "lint"
       },
       {
-        "column": 57,
-        "index": 8363,
-        "line": 269,
-        "loc": {
-          "end": {
-            "column": 66,
-            "line": 269
-          },
-          "start": {
-            "column": 57,
-            "line": 269
-          }
-        },
-        "message": "LLM vocabulary found: \"intricate\". Replace the stock diction with a concrete word.",
-        "range": [
-          8363,
-          8372
-        ],
-        "ruleId": "llm-vocabulary",
-        "severity": 2,
-        "type": "lint"
-      },
-      {
-        "column": 67,
-        "index": 8373,
-        "line": 269,
-        "loc": {
-          "end": {
-            "column": 75,
-            "line": 269
-          },
-          "start": {
-            "column": 67,
-            "line": 269
-          }
-        },
-        "message": "LLM vocabulary found: \"tapestry\". Replace the stock diction with a concrete word.",
-        "range": [
-          8373,
-          8381
-        ],
-        "ruleId": "llm-vocabulary",
-        "severity": 2,
-        "type": "lint"
-      },
-      {
         "column": 67,
         "index": 8373,
         "line": 269,
@@ -2253,29 +2000,6 @@
           8381
         ],
         "ruleId": "prohibited-words",
-        "severity": 2,
-        "type": "lint"
-      },
-      {
-        "column": 1,
-        "index": 8563,
-        "line": 277,
-        "loc": {
-          "end": {
-            "column": 9,
-            "line": 277
-          },
-          "start": {
-            "column": 1,
-            "line": 277
-          }
-        },
-        "message": "LLM vocabulary found: \"Moreover\". Replace the stock diction with a concrete word.",
-        "range": [
-          8563,
-          8571
-        ],
-        "ruleId": "llm-vocabulary",
         "severity": 2,
         "type": "lint"
       },

--- a/behavior/golden/textlint-rules-corpus-engineering-review/approved.meta.json
+++ b/behavior/golden/textlint-rules-corpus-engineering-review/approved.meta.json
@@ -1,10 +1,10 @@
 {
   "suite": "textlint-rules-corpus-engineering-review",
   "kind": "approved",
-  "run_id": "2026-06-01T15-47-29.493694Z-04547efb",
-  "run_commit": "2f16376",
+  "run_id": "2026-06-01T16-23-56.584734Z-04547efb",
+  "run_commit": "208fd3d",
   "working_tree": "dirty",
-  "recorded_at": "2026-06-01T15:47:29.493694Z",
+  "recorded_at": "2026-06-01T16:23:56.584734Z",
   "fixture_hash": "sha256:eaa061434d3460408c6d4162f654e455cfe2c58a4cb7b714091df9f6c879cf91",
   "manifest_hash": "sha256:04547efbb13157ee3d8ef18dda767231fd63d3f9cc27c15317cf28c5f0583e7b",
   "tool_version": "0.1.8",
@@ -15,5 +15,5 @@
       "sha256": "sha256:653e4966fd039ccce4ca6bf04b7d5a3ff2f8b9a084edf616a49e00436cf8030d"
     }
   ],
-  "comment": "triple-repeat precision: gate bare openers to non-stop-words and skip empty opener; removes common-opener false positives (the/it/she/they/...)"
+  "comment": "simplicity + llm-vocabulary now density-based: removes per-instance single-word false positives; density cluster hits retained"
 }

--- a/behavior/golden/textlint-rules-corpus-engineering-review/approved.normalized.json
+++ b/behavior/golden/textlint-rules-corpus-engineering-review/approved.normalized.json
@@ -7031,29 +7031,6 @@
             "line": 599
           }
         },
-        "message": "LLM vocabulary found: \"delve\". Replace the stock diction with a concrete word.",
-        "range": [
-          24791,
-          24796
-        ],
-        "ruleId": "llm-vocabulary",
-        "severity": 2,
-        "type": "lint"
-      },
-      {
-        "column": 7,
-        "index": 24791,
-        "line": 599,
-        "loc": {
-          "end": {
-            "column": 12,
-            "line": 599
-          },
-          "start": {
-            "column": 7,
-            "line": 599
-          }
-        },
         "message": "Prohibited word found: \"delve\". Rewrite without this term.",
         "range": [
           24791,
@@ -7083,29 +7060,6 @@
           24884
         ],
         "ruleId": "response-wrapper",
-        "severity": 2,
-        "type": "lint"
-      },
-      {
-        "column": 13,
-        "index": 24859,
-        "line": 601,
-        "loc": {
-          "end": {
-            "column": 18,
-            "line": 601
-          },
-          "start": {
-            "column": 13,
-            "line": 601
-          }
-        },
-        "message": "LLM vocabulary found: \"delve\". Replace the stock diction with a concrete word.",
-        "range": [
-          24859,
-          24864
-        ],
-        "ruleId": "llm-vocabulary",
         "severity": 2,
         "type": "lint"
       },
@@ -7313,29 +7267,6 @@
           25237
         ],
         "ruleId": "response-wrapper",
-        "severity": 2,
-        "type": "lint"
-      },
-      {
-        "column": 27,
-        "index": 25201,
-        "line": 615,
-        "loc": {
-          "end": {
-            "column": 32,
-            "line": 615
-          },
-          "start": {
-            "column": 27,
-            "line": 615
-          }
-        },
-        "message": "LLM vocabulary found: \"delve\". Replace the stock diction with a concrete word.",
-        "range": [
-          25201,
-          25206
-        ],
-        "ruleId": "llm-vocabulary",
         "severity": 2,
         "type": "lint"
       },
@@ -9709,29 +9640,6 @@
         "type": "lint"
       },
       {
-        "column": 24,
-        "index": 39122,
-        "line": 989,
-        "loc": {
-          "end": {
-            "column": 37,
-            "line": 989
-          },
-          "start": {
-            "column": 24,
-            "line": 989
-          }
-        },
-        "message": "LLM vocabulary found: \"comprehensive\". Replace the stock diction with a concrete word.",
-        "range": [
-          39122,
-          39135
-        ],
-        "ruleId": "llm-vocabulary",
-        "severity": 2,
-        "type": "lint"
-      },
-      {
         "column": 1,
         "index": 39209,
         "line": 991,
@@ -9912,29 +9820,6 @@
           39866
         ],
         "ruleId": "academic-boilerplate",
-        "severity": 2,
-        "type": "lint"
-      },
-      {
-        "column": 26,
-        "index": 39894,
-        "line": 1003,
-        "loc": {
-          "end": {
-            "column": 34,
-            "line": 1003
-          },
-          "start": {
-            "column": 26,
-            "line": 1003
-          }
-        },
-        "message": "LLM vocabulary found: \"tapestry\". Replace the stock diction with a concrete word.",
-        "range": [
-          39894,
-          39902
-        ],
-        "ruleId": "llm-vocabulary",
         "severity": 2,
         "type": "lint"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "slopless",
-  "version": "0.2.15",
+  "version": "0.2.16",
   "description": "Deterministic textlint rules and CLI for catching prose slop in English Markdown.",
   "keywords": [
     "textlint",

--- a/src/rules/words/llm-vocabulary.ts
+++ b/src/rules/words/llm-vocabulary.ts
@@ -1,6 +1,19 @@
-import { findVocabularyMatches } from "./private/vocabulary-context.js";
-import { oneToOneRule } from "../private/textlint-rule-builders.js";
+import { defineTextlintRule } from "../../adapters/textlint/rule.js";
+import { paragraphUnits } from "../../adapters/textlint/units.js";
+import { wordTokens } from "../../shared/text/tokens.js";
+import { isVocabularyContextAllowed } from "./private/vocabulary-context.js";
+import type { RuleDetection, RuleId, TextUnit } from "../types.js";
 
+const RULE_ID = "words:llm-vocabulary" satisfies RuleId;
+const GROUP = "llm vocabulary";
+const MAX_PARAGRAPH_TOKENS = 90;
+const MAX_WINDOW_TOKENS = 65;
+const MIN_HITS = 3;
+const WINDOW_SENTENCES = 4;
+
+// Single stock words like "comprehensive" or "moreover" are ordinary in human
+// prose; flag only when stock LLM diction clusters. (Words that are slop on
+// their own, e.g. "delve", are still caught per-instance by prohibited-words.)
 const LLM_VOCABULARY = new Set([
   "delve",
   "vibrant",
@@ -16,18 +29,47 @@ const LLM_VOCABULARY = new Set([
   "tapestry"
 ]);
 
-const rule = oneToOneRule({
-  detect: (unit) =>
-    findVocabularyMatches(unit.text, [...LLM_VOCABULARY]).map((match) => ({
-      evidence: match.text,
-      label: match.text,
-      range: { start: match.start, end: match.end }
-    })),
-  family: "words",
-  formatMessage: (report) =>
-    `LLM vocabulary found: "${report.evidence}". Replace the stock diction with a concrete word.`,
-  ruleId: "words:llm-vocabulary",
-  unitKind: "str"
+type VocabularyGroup = typeof GROUP;
+
+function vocabularyDetections(
+  unit: TextUnit
+): RuleDetection<VocabularyGroup>[] {
+  return wordTokens(unit.text)
+    .filter(
+      (token) =>
+        LLM_VOCABULARY.has(token.normalized) &&
+        !isVocabularyContextAllowed(unit.text, token.normalized)
+    )
+    .map((token) => ({
+      evidence: unit.text.slice(token.start, token.end),
+      group: GROUP,
+      label: token.normalized,
+      range: { end: token.end, start: token.start },
+      ruleId: RULE_ID,
+      unitId: unit.id
+    }));
+}
+
+const rule = defineTextlintRule({
+  detector: {
+    detect: ({ units }) => units.flatMap((unit) => vocabularyDetections(unit)),
+    family: "words",
+    id: RULE_ID
+  },
+  formatMessage: (report) => {
+    const labels = [...new Set(report.detections.map((hit) => hit.label))];
+    return `LLM vocabulary density: ${report.detections.length} stock words in a short span (${labels.join(", ")}). Replace the stock diction with concrete words.`;
+  },
+  reportPolicy: {
+    groups: [GROUP],
+    kind: "density",
+    maxParagraphTokens: MAX_PARAGRAPH_TOKENS,
+    maxWindowTokens: MAX_WINDOW_TOKENS,
+    paragraphMinimumHits: MIN_HITS,
+    windowMinimumHits: MIN_HITS,
+    windowSentences: WINDOW_SENTENCES
+  },
+  units: (document) => paragraphUnits(document)
 });
 
 export default rule;

--- a/src/rules/words/simplicity.ts
+++ b/src/rules/words/simplicity.ts
@@ -1,33 +1,59 @@
 import simplicityPairs from "./data/simplicity-pairs.json" with { type: "json" };
+import { defineTextlintRule } from "../../adapters/textlint/rule.js";
+import { paragraphUnits } from "../../adapters/textlint/units.js";
 import { wordTokens } from "../../shared/text/tokens.js";
-import { oneToOneRule } from "../private/textlint-rule-builders.js";
+import type { RuleDetection, RuleId, TextUnit } from "../types.js";
 
-const SIMPLE_BY_COMPLEX = new Map(
-  simplicityPairs.map(([complex, simple]) => [complex, simple])
+const RULE_ID = "words:simplicity" satisfies RuleId;
+const GROUP = "complex word";
+const MAX_PARAGRAPH_TOKENS = 90;
+const MAX_WINDOW_TOKENS = 65;
+const MIN_HITS = 2;
+const WINDOW_SENTENCES = 4;
+
+// A single complex word is not slop; one "numerous" or "utilize" is ordinary.
+// Flag only when complex diction clusters, which is what makes prose feel dense.
+const COMPLEX_WORDS = new Set<string>(
+  simplicityPairs
+    .map((pair) => pair[0])
+    .filter((word): word is string => word !== undefined)
 );
 
-const rule = oneToOneRule({
-  detect: (unit) =>
-    wordTokens(unit.text).flatMap((token) => {
-      const simple = SIMPLE_BY_COMPLEX.get(token.normalized);
-      if (simple === undefined) {
-        return [];
-      }
+type SimplicityGroup = typeof GROUP;
 
-      return [
-        {
-          data: { simple },
-          evidence: token.text,
-          label: token.text,
-          range: { start: token.start, end: token.end }
-        }
-      ];
-    }),
-  family: "words",
-  formatMessage: (report) =>
-    `Complex word found: "${report.evidence}". Use "${report.detections[0]?.data?.["simple"]}" instead.`,
-  ruleId: "words:simplicity",
-  unitKind: "sentence"
+function complexDetections(unit: TextUnit): RuleDetection<SimplicityGroup>[] {
+  return wordTokens(unit.text)
+    .filter((token) => COMPLEX_WORDS.has(token.normalized))
+    .map((token) => ({
+      evidence: unit.text.slice(token.start, token.end),
+      group: GROUP,
+      label: token.normalized,
+      range: { end: token.end, start: token.start },
+      ruleId: RULE_ID,
+      unitId: unit.id
+    }));
+}
+
+const rule = defineTextlintRule({
+  detector: {
+    detect: ({ units }) => units.flatMap((unit) => complexDetections(unit)),
+    family: "words",
+    id: RULE_ID
+  },
+  formatMessage: (report) => {
+    const labels = [...new Set(report.detections.map((hit) => hit.label))];
+    return `Complex word density: ${report.detections.length} complex words in a short span (${labels.join(", ")}). Prefer simpler wording.`;
+  },
+  reportPolicy: {
+    groups: [GROUP],
+    kind: "density",
+    maxParagraphTokens: MAX_PARAGRAPH_TOKENS,
+    maxWindowTokens: MAX_WINDOW_TOKENS,
+    paragraphMinimumHits: MIN_HITS,
+    windowMinimumHits: MIN_HITS,
+    windowSentences: WINDOW_SENTENCES
+  },
+  units: (document) => paragraphUnits(document)
 });
 
 export default rule;


### PR DESCRIPTION
## What

Residual precision work from the false-positive audit. The per-instance `simplicity` and `llm-vocabulary` rules over-fired on ordinary single words in human prose (1,723 and 765 false positives in the audit). Both now fire only when stock/complex diction clusters, mirroring the existing `llm-vocabulary-density` rule.

- **simplicity**: density over its 5 complex words (utilize/implement/facilitate/numerous/commence), `MIN_HITS=2`.
- **llm-vocabulary**: density over its 12 stock words, `MIN_HITS=3`, keeping the context gate. Single-word slop like "delve" is still caught per-instance by `prohibited-words`.

## Verification
- 100 Wikipedia files: both rules now fire **0** (were hundreds of per-instance hits). Fires on real clusters, not single words. AI marketing clustering still caught by `llm-vocabulary-density`.
- Goldens re-approved for the 5 suites whose only drift was these two rules; fixture density coverage preserved (cases/words hits.md lines 29, 31). `fixture3 check --all` matches on all 19 suites.
- eslint, prettier, cspell, type-coverage 100%, build pass.

Release 0.2.16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)