### PR TITLE
Harden CI: SHA-pin actions + scope token permissions + dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,10 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    # Wait 2 days after a release before opening a PR, so bumps clear pnpm's 24h
+    # minimumReleaseAge supply-chain gate and do not fail `pnpm install --frozen-lockfile`.
+    cooldown:
+      default-days: 2
     groups:
       dev-dependencies:
         dependency-type: "development"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     name: Validate
@@ -13,13 +16,15 @@ jobs:
       matrix:
         node: ["22", "24"]
     steps:
-      - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: g3ts
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v6
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: ${{ matrix.node }}
           cache: pnpm

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -20,25 +20,25 @@ jobs:
       actions: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
 
       - name: Run analysis
-        uses: ossf/scorecard-action@v2.4.0
+        uses: ossf/scorecard-action@62b2cac7ed8198b15735ed49ab1e5cf35480ba46 # v2.4.0
         with:
           results_file: results.sarif
           results_format: sarif
           publish_results: true
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: SARIF file
           path: results.sarif
           retention-days: 5
 
       - name: Upload to code-scanning
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@87557b9c84dde89fdd9b10e88954ac2f4248e463 # v4
         with:
           sarif_file: results.sarif

--- a/.worklogs/2026-06-02-183255-security-hardening.md
+++ b/.worklogs/2026-06-02-183255-security-hardening.md
@@ -1,0 +1,35 @@
+# Security hardening: SHA-pin actions, ci permissions, dependabot cooldown
+
+## Summary
+
+OpenSSF Scorecard quick wins + the proper resolution of the Dependabot GitHub-Actions PRs.
+
+## Changes
+
+- ci.yml: added top-level `permissions: contents: read` (Token-Permissions 0 -> ~9; the
+  repo default was already read, so this is purely declarative, zero risk).
+- SHA-pinned every GitHub Action across ci.yml + scorecard.yml to a full commit SHA with a
+  `# version` comment (Pinned-Dependencies 0 -> ~9): checkout v6, setup-node v6,
+  pnpm/action-setup v6, rust-toolchain stable (+ explicit `toolchain: stable` since the SHA
+  ref no longer infers the channel), rust-cache v2, ossf/scorecard-action v2.4.0,
+  upload-artifact v7, codeql-action/upload-sarif v4.
+- This incorporates the targets of Dependabot #54 (codeql 3->4), #55 (action-setup 4->6),
+  #57 (upload-artifact 4->7) and supersedes the stale #56/#58 (checkout/setup-node already
+  v6 on ci.yml). Those PRs will be closed as superseded.
+- dependabot.yml: added `cooldown: default-days: 2` to the npm updater so bumps clear
+  pnpm 11's 24h minimumReleaseAge gate before a PR opens (this is what broke #60's
+  `pnpm install --frozen-lockfile`).
+
+## Not done (reported for decision)
+
+- Require >=1 approving review on main: the single biggest OpenSSF detractor (Code-Review
+  0), but a real workflow change for a solo maintainer. Left to the maintainer.
+- qs -> 6.15.2 pnpm override: clears the one transitive Socket/GHSA advisory, but it is a
+  band-aid on a transitive dep and risks the same minimumReleaseAge gate locally. Left out;
+  Socket 79 is driven by this one non-default-path medium advisory + new-package noise.
+- Finishing the OpenSSF Best Practices (CII) badge: form-filling, no code.
+
+## Verify
+
+- Workflow + dependabot YAML prettier-clean.
+- PR CI must confirm the SHA pins + rust-toolchain change still build/validate.


### PR DESCRIPTION
OpenSSF Scorecard quick wins and the resolution of the Dependabot GitHub Actions PRs. Adds `permissions: contents: read` to ci.yml, SHA-pins every action in ci.yml + scorecard.yml (supersedes #54/#55/#57; #56/#58 were stale), and adds a dependabot npm cooldown so bumps clear pnpm's 24h minimumReleaseAge gate (cause of #60).