### PR TITLE
Drop scorecard badge, override qs to patched 6.15.2, ignore @types/node major

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,11 @@ updates:
     # minimumReleaseAge supply-chain gate and do not fail `pnpm install --frozen-lockfile`.
     cooldown:
       default-days: 2
+    ignore:
+      # Keep @types/node aligned with the supported Node baseline (engines: node >=22).
+      # Do not jump it a major ahead of the runtime it is typed against.
+      - dependency-name: "@types/node"
+        update-types: ["version-update:semver-major"]
     groups:
       dev-dependencies:
         dependency-type: "development"

--- a/.plans/2026-05-23-152521-promotion-master.md
+++ b/.plans/2026-05-23-152521-promotion-master.md
@@ -314,3 +314,13 @@ Skipped artifact backlog:
 **Week 12+ (2026-08-14, 2026-08-16):** Wave 4 unblocks - submit agarrharr/awesome-cli-apps and analysis-tools-dev/static-analysis. Reassess awesome-nodejs after July re-open.
 
 **Continuous:** Wave 5 monitoring - check Socket/Snyk/Scorecard score deltas after each artifact ships.
+
+---
+
+## Deferred until a second maintainer (ideal multi-dev GitHub profile)
+
+These lift the OpenSSF Scorecard but cannot be done well solo; revisit when a second developer is on the repo.
+
+- **Require >=1 approving review on `main`.** The single biggest Scorecard detractor (Code-Review 0/10, "0 of N approved changesets"). It needs a second person to approve PRs, so it is on hold during the solo phase.
+- **Re-add the OpenSSF Scorecard badge to the README.** Removed 2026-06-02: the headline 5.2 is dragged down mainly by Code-Review 0, which the item above blocks. Re-add once review enforcement is on and the number reflects the CI hardening already shipped (Token-Permissions + Pinned-Dependencies fixed by SHA-pinning every action in #69). The Socket badge stays.
+- Solo-friendly, optional now: finish the OpenSSF Best Practices (CII) badge questionnaire (form-filling, no second person needed).

--- a/.worklogs/2026-06-02-190858-drop-scorecard-badge-qs-override.md
+++ b/.worklogs/2026-06-02-190858-drop-scorecard-badge-qs-override.md
@@ -1,0 +1,26 @@
+# Drop scorecard badge; qs override; @types/node ignore
+
+## Summary
+
+Post-review config follow-ups from the badge/score pass.
+
+## Changes
+
+- README: removed the OpenSSF Scorecard badge. Its headline (5.2) is dragged down mostly by
+  Code-Review 0/10, which requires a second reviewer on main - deferred while solo. Socket
+  badge stays.
+- .plans/2026-05-23-152521-promotion-master.md: recorded the deferred multi-dev items
+  (require >=1 review on main; re-add the scorecard badge once review enforcement is on and
+  the score reflects the #69 hardening).
+- pnpm-workspace.yaml: added an `overrides` entry forcing the patched `qs` 6.15.2 across the
+  transitive tree (textlint -> MCP SDK -> express -> body-parser -> qs), clearing CVE-2026-8723.
+  Note: pnpm 11 no longer reads `overrides` from package.json's `pnpm` field - it must live in
+  pnpm-workspace.yaml. Verified the lockfile resolves qs to 6.15.2 only and
+  `pnpm install --frozen-lockfile` passes (qs 6.15.2 is ~17 days old, clear of pnpm's 24h gate).
+- .github/dependabot.yml: ignore `@types/node` semver-major so it stays aligned with the
+  Node-22 baseline (engines: node >=22), not jumped ahead of the runtime it types.
+
+## Verify
+
+- `pnpm run validate` passes (build, lint, prettier, cspell, type-coverage 100).
+- `pnpm install --frozen-lockfile` clean; qs resolves to 6.15.2 across the tree.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@
 [![node](https://img.shields.io/badge/node-22%2B-brightgreen)](package.json)
 
 [![ci](https://img.shields.io/github/actions/workflow/status/seochecks-ai%2Fslopless/ci.yml?branch=main&label=ci)](/actions/workflows/ci.yml)
-[![scorecard](https://api.scorecard.dev/projects/github.com/seochecks-ai/slopless/badge)](https://scorecard.dev/viewer/?uri=github.com/seochecks-ai/slopless)
 [![socket](https://socket.dev/api/badge/npm/package/slopless)](https://socket.dev/npm/package/slopless)
 
 Catch AI and human slop in English Markdown without calling an LLM. Slopless ships 50+ deterministic textlint rules and a CLI that emits structured JSON findings.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  qs@>=6.11.1 <=6.15.1: 6.15.2
+
 importers:
 
   .:
@@ -2145,8 +2148,8 @@ packages:
     resolution: {integrity: sha512-+Owyggi9IxT1ePKGafcI87ubSmxol6smwJ+RAHDQlx9+9cPwFWDiKFFCPuWhr9ignlGpZ9vDQLw67N4dcTVFEA==}
     engines: {node: '>=20'}
 
-  qs@6.15.1:
-    resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
+  qs@6.15.2:
+    resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
     engines: {node: '>=0.6'}
 
   queue-microtask@1.2.3:
@@ -3556,7 +3559,7 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       on-finished: 2.4.1
-      qs: 6.15.1
+      qs: 6.15.2
       raw-body: 3.0.2
       type-is: 2.0.1
     transitivePeerDependencies:
@@ -4051,7 +4054,7 @@ snapshots:
       once: 1.4.0
       parseurl: 1.3.3
       proxy-addr: 2.0.7
-      qs: 6.15.1
+      qs: 6.15.2
       range-parser: 1.2.1
       router: 2.2.0
       send: 1.2.1
@@ -4892,7 +4895,7 @@ snapshots:
     dependencies:
       hookified: 2.2.0
 
-  qs@6.15.1:
+  qs@6.15.2:
     dependencies:
       side-channel: 1.1.0
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,6 @@
 allowBuilds:
   unrs-resolver: true
+overrides:
+  # Force the patched qs across the transitive tree (textlint -> MCP SDK -> express ->
+  # body-parser -> qs). Clears the qs advisory CVE-2026-8723 (DoS, affects qs <=6.15.1).
+  "qs@>=6.11.1 <=6.15.1": "6.15.2"


### PR DESCRIPTION
Per review: remove the OpenSSF Scorecard badge (Code-Review 0/10 needs a second reviewer; deferred to the promotion plan, Socket badge stays); add a pnpm-workspace.yaml override forcing qs 6.15.2 across the transitive tree (CVE-2026-8723, pnpm 11 reads overrides here not in package.json); ignore @types/node semver-major to keep it on the Node-22 baseline. validate + frozen-lockfile pass.