### PR TITLE
Release slopless 0.2.21

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "slopless",
-  "version": "0.2.20",
+  "version": "0.2.21",
   "description": "Deterministic textlint rules and CLI for catching prose slop in English Markdown.",
   "keywords": [
     "textlint",


### PR DESCRIPTION
Docs/metadata release: updated README (new example, core-help line, dropped dead badges, credits) plus the CI hardening, qs override, and @types/node ignore already on main since 0.2.20. No rule/dist changes.