### PR TITLE
ci: SHA-pin release.yml actions to v6

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,9 +15,9 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: "22"
           cache: pnpm

--- a/.worklogs/2026-06-03-221938-pin-release-yml-actions.md
+++ b/.worklogs/2026-06-03-221938-pin-release-yml-actions.md
@@ -1,0 +1,20 @@
+# Pin release.yml actions to SHA-pinned v6
+
+## Summary
+`release.yml` still used unpinned `@v4` actions (actions/checkout, pnpm/action-setup,
+actions/setup-node) running on Node 20, which GitHub deprecated (forced to Node 24 on 2026-06-16) and
+which the security-hardening pass had pinned everywhere else. Bumped all three to the same SHA-pinned
+v6 refs `ci.yml` uses. `ci.yml` and `scorecard.yml` were already fully pinned; this was the last gap.
+
+## Why these SHAs
+Reused ci.yml's exact pins so versions match across workflows:
+- actions/checkout@de0fac2... (v6)
+- pnpm/action-setup@0e279bb... (v6)
+- actions/setup-node@48b55a0... (v6)
+
+## Note
+Shipped on a throwaway branch (not `development`) so the release-PR auto-delete-head-branch setting
+doesn't delete the working trunk again.
+
+## Key files
+- `.github/workflows/release.yml`


### PR DESCRIPTION
release.yml used unpinned @v4 actions on Node 20 (deprecated; forced to Node 24 on 2026-06-16). Pin checkout / pnpm-action-setup / setup-node to the same v6 SHAs ci.yml uses. Last unpinned workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)