### PR TITLE
Release slopless 0.2.24

### DIFF
--- a/.plans/2026-07-02-142109-negation-surface-forms.md
+++ b/.plans/2026-07-02-142109-negation-surface-forms.md
@@ -1,0 +1,30 @@
+Goal:
+Extend negation-reframe detection so sloppy negation templates survive surface-form changes such as `not` -> `never`, `isn't`, `doesn't`, and pronoun contractions like `it's`.
+
+Approach:
+- Update `src/rules/syntactic-patterns/contrast/private/negation-reframe-parts.ts` to model negation forms as shared syntax:
+  - include `never` in negation words
+  - let copular negation find `is never`, `was never`, and equivalent copular forms
+  - normalize pronoun copula starts such as `it's`, `that's`, `they're`, `we're`, and `you're`
+  - add helpers for do-negated lexical actions so `doesn't replace` and `does not replace` share one path
+- Update `src/rules/syntactic-patterns/contrast/private/negation-reframe-matcher.ts`:
+  - use the broader copular helper for pair reframes
+  - add a negated lexical-action -> pronoun payoff branch for patterns like `RAG doesn't replace search. It depends on it.`
+- Keep factual guards:
+  - do not flag negations with factual connectors after the negation
+  - do not flag technical/passive definition pairs
+  - keep existing concrete-correction guard for explicit replacement frames
+- Add hit and no-hit cases to `behavior/fixtures/textlint-rules/cases/syntactic-patterns`.
+- Review and approve only the syntactic-patterns golden output if the diff matches the intended behavior.
+
+Key decisions:
+- Do not add a separate rule. These are forms of `negation-reframe`, so the rule ID should stay stable.
+- Do not rely on literal phrase lists for `never` or `doesn't`; normalize the operator and reuse pair logic.
+- Keep the change pair-based. Single-sentence negation widening is a different false-positive surface.
+
+Files to modify:
+- `src/rules/syntactic-patterns/contrast/private/negation-reframe-parts.ts`
+- `src/rules/syntactic-patterns/contrast/private/negation-reframe-matcher.ts`
+- `behavior/fixtures/textlint-rules/cases/syntactic-patterns/hits.md`
+- `behavior/fixtures/textlint-rules/cases/syntactic-patterns/no-hits.md`
+- `behavior/golden/textlint-rules-cases-syntactic-patterns/*` after review

--- a/.plans/2026-07-03-133106-negation-informativeness-gate.md
+++ b/.plans/2026-07-03-133106-negation-informativeness-gate.md
@@ -1,0 +1,33 @@
+# Negation reframe classification
+
+Goal:
+Change only `syntactic-patterns:negation-reframe` so it keeps known sloppy reframes, including detailed ones, while suppressing concrete factual corrections.
+
+Approach:
+- Replace the universal informativeness gate with a private pair classifier beside the sentence-pair matcher.
+- Keep short label reversals without applying a factual-correction suppression.
+- Keep reframes whose subject or first four words after the negation contain a framing noun: `goal`, `answer`, `fix`, `solution`, `point`, `problem`, `strategy`, `key`, or `issue`. The bounded predicate check catches `This is not a coffee problem` without treating later technical uses such as `problem statement` as framing.
+- Keep action-payoff patterns such as `RAG does not replace search. It depends on it.` without applying the copular factual-correction suppression.
+- For other broad copular pairs, suppress only when the replacement has a factual structure: a direct instruction; ownership, purpose, definition, amount, symptom, or distinct-cause wording; causal provenance; or reference evidence combined with a passive explanation. A repeated `not caused by X, caused by Y` contrast remains reportable. Neither reference evidence nor a passive verb is sufficient alone. A single number, names, sentence length, an explanatory clause, or `part of` is not sufficient because corpus testing showed that each also occurs in known slop.
+- Apply the same classifier to explicit contrast pivots, but require combined factual evidence so detail alone cannot suppress them. Corpus testing must retain clear slop such as `This is not a framework. It is a calibration layer.` and `These are not experimental toys anymore. They are the new default workflow.`
+- Keep detailed metaphorical or evaluative replacements that lack that evidence.
+- Keep the requested hit examples: `It is never sudden. It is timely.`, `It was nobody important. It was a guest.`, `RAG does not replace search. It depends on it.`, and `Indexing is not the boring technical step anymore. It is the gate everything else has to pass through.`
+- Add hit coverage for detailed goal/fix/answer reframes and detailed metaphorical product or self-help reframes that the rejected universal gate removed.
+- Add no-hit coverage for the observed protocol, biography/history, health, medical-definition, and financial/legal factual corrections.
+- Run fixture3 on syntactic-patterns, inspect diff, and do not approve blindly.
+- Compare current changed-rule behavior against the previous committed behavior on human, ai-suspected, and ai-generated corpora with a direct matcher audit. Report gained/lost hits and manually classify representative changes.
+
+Key decisions:
+- The boundary is communicative function, not the spelling of the negator or sentence length.
+- The fix belongs in the rule matcher, because the false positives are produced before reporting.
+- Pattern-specific decisions replace one universal gate because the broad pair patterns do not share one safe boundary.
+- Keep the public rule ID unchanged.
+
+Files to modify:
+- src/rules/syntactic-patterns/contrast/private/negation-reframe-matcher.ts
+- src/rules/syntactic-patterns/contrast/private/copular-reframe.ts
+- src/rules/syntactic-patterns/contrast/private/negation-reframe-parts.ts
+- src/rules/syntactic-patterns/contrast/private/reframe-classification.ts
+- src/rules/syntactic-patterns/contrast/private/negative-slop-frames.ts
+- behavior/fixtures/textlint-rules/cases/syntactic-patterns/hits.md
+- behavior/fixtures/textlint-rules/cases/syntactic-patterns/no-hits.md

--- a/.plans/2026-07-03-133106-negation-informativeness-gate.md.spec.coverage.md
+++ b/.plans/2026-07-03-133106-negation-informativeness-gate.md.spec.coverage.md
@@ -1,0 +1,22 @@
+# Negation reframe classification coverage
+
+## Goal
+
+- Fixture3: `textlint-rules-cases-syntactic-patterns` verifies which negation pairs report and which remain clean.
+- Manual corpus comparison: changed `negation-reframe` findings are compared across human, suspected-AI, and generated-AI corpora.
+
+## Approach
+
+- Specular tree requirement: the private classifier, copular matcher, pair matcher, frame module, and both fixture files must exist.
+- Fixture3: short reversals, framing-subject reframes, action-payoff reframes, concrete factual corrections, and detailed evaluative replacements are checked through public rule output.
+- Manual corpus comparison: concrete-evidence suppression and retained detailed slop are reviewed from changed findings.
+
+## Key decisions
+
+- Fixture3: the public rule ID remains `syntactic-patterns:negation-reframe` in public findings.
+- Specular tree requirement: classification remains private to the syntactic-patterns rule implementation.
+- Code review: no reporting or unrelated family code participates in the decision.
+
+## Files to modify
+
+- Specular tree requirement: every listed implementation and fixture path is required.

--- a/.plans/2026-07-03-133106-negation-informativeness-gate.md.spec.json
+++ b/.plans/2026-07-03-133106-negation-informativeness-gate.md.spec.json
@@ -1,0 +1,18 @@
+{
+  "version": 4,
+  "requirements": {
+    "tree": {
+      "verifier": ["builtin:tree"],
+      "reason": "plan: Files to modify and private pair classifier module",
+      "required": [
+        "src/rules/syntactic-patterns/contrast/private/negation-reframe-matcher.ts",
+        "src/rules/syntactic-patterns/contrast/private/copular-reframe.ts",
+        "src/rules/syntactic-patterns/contrast/private/negation-reframe-parts.ts",
+        "src/rules/syntactic-patterns/contrast/private/reframe-classification.ts",
+        "src/rules/syntactic-patterns/contrast/private/negative-slop-frames.ts",
+        "behavior/fixtures/textlint-rules/cases/syntactic-patterns/hits.md",
+        "behavior/fixtures/textlint-rules/cases/syntactic-patterns/no-hits.md"
+      ]
+    }
+  }
+}

--- a/.plans/2026-07-21-160459-slop-pattern-expansion.md
+++ b/.plans/2026-07-21-160459-slop-pattern-expansion.md
@@ -23,7 +23,7 @@ Catch the seven supplied slop constructions by extending their existing rule own
    - Preserve factual-connector rejection.
    - Keep direct abstract-object parsing in a private contrast helper so the negation matcher stays below the repository file-size limit.
 6. Add `empty-quantification.json` under semantic-thinness:
-   - Match `just`, `simply`, `merely`, or `basically` plus `put a number on` plus `it`, `this`, or `that` in contains mode.
+   - Match `just`, `simply`, `merely`, or `basically` plus `put a number on` plus `it`, `this`, or `that` in suffix mode, allowing an arbitrary subject while rejecting measured or literal continuations.
    - Keep numbered labels, measured values, and explanations with existing concrete-evidence and connector guards outside the pattern.
    - Import the pattern through the existing pattern-data module. Do not add a public rule ID.
 7. Add isolated public hit and no-hit cases to the existing syntactic-patterns and semantic-thinness fixture files before accepting output.

--- a/.plans/2026-07-21-160459-slop-pattern-expansion.md
+++ b/.plans/2026-07-21-160459-slop-pattern-expansion.md
@@ -1,0 +1,54 @@
+# Slop pattern expansion
+
+## Goal
+
+Catch the seven supplied slop constructions by extending their existing rule owners wherever one exists. Add one semantic-thinness pattern for empty quantification because no current detector owns that behavior. Keep concrete literal uses clean.
+
+## Approach
+
+1. Extend the private discourse-evaluation matcher used by `syntactic-patterns:generic-signposting`:
+   - Match discourse subjects followed by `is doing real work`.
+   - Match discourse subjects followed by `is load-bearing`, tokenized as `is load bearing`.
+   - Require a known discourse noun for both forms so literal subjects such as `crew`, `wall`, and `beam` remain clean.
+2. Extend the abstract-frame matcher in `generic-signposting`:
+   - Generalize the existing `the result worth caring about` form to known frame nouns followed by `worth paying attention to`, `worth noticing`, `worth watching`, `worth tracking`, or `worth caring about`.
+   - Match `the` plus an evaluative adjective plus a frame noun plus `starts`, `begins`, `happens`, or `lives` plus a vague location such as `upstream`, `downstream`, `here`, `there`, or `earlier`.
+   - Add `audit` and `diagnosis` to the existing frame-noun inventory.
+   - Keep the existing concrete-implementation guard, including numbers and technical objects.
+3. Add `the fun part is` to the sentence-level formulaic lead-ins in `syntactic-patterns:generic-signposting`. Do not put it in `llm-openers`, because that rule only sees the first sentence of a Markdown section and would miss ordinary paragraph lead-ins.
+4. Extend `syntactic-patterns:affirmation-closers` with the exact short formula `that's the good stuff` and its uncontracted form. Do not match longer literal references to purchased or selected goods.
+5. Extend `syntactic-patterns:negation-reframe`:
+   - Add `set` as a replacement action only when its nearby object is an abstract policy noun such as `rule`, `policy`, `criterion`, `threshold`, `condition`, `requirement`, `principle`, or `standard`.
+   - Permit a colon-ended second sentence only for this negated-action replacement path. Do not make colon endings complete sentences for every negation matcher.
+   - Preserve factual-connector rejection.
+   - Keep direct abstract-object parsing in a private contrast helper so the negation matcher stays below the repository file-size limit.
+6. Add `empty-quantification.json` under semantic-thinness:
+   - Match `just`, `simply`, `merely`, or `basically` plus `put a number on` plus `it`, `this`, or `that` in contains mode.
+   - Keep numbered labels, measured values, and explanations with existing concrete-evidence and connector guards outside the pattern.
+   - Import the pattern through the existing pattern-data module. Do not add a public rule ID.
+7. Add isolated public hit and no-hit cases to the existing syntactic-patterns and semantic-thinness fixture files before accepting output.
+8. Run direct public CLI probes, Fixture3, repository validation, and targeted changed-rule audits over human, suspected-AI, and generated-AI corpora. Review all changed findings before approval.
+
+## Key decisions
+
+- Reuse `generic-signposting`, `affirmation-closers`, `negation-reframe`, and `semantic-thinness`; the supplied forms do not justify another public rule family.
+- Do not add a wildcard to the semantic template engine. Existing token matchers already support generalized discourse subjects, and the empty-quantification pattern can begin at the diagnostic phrase rather than enumerating arbitrary subjects.
+- Do not treat every colon-ended fragment as a sentence. The exception belongs only to the negated-action replacement that needs it.
+- Prefer a constrained abstract-object inventory for `set` over banning every `did not X. She set Y:` pair.
+- Err toward reporting formulaic prose, but retain literal walls, beams, crews, numbered labels, measurements, and factual explanations as no-hits.
+
+## Files to modify
+
+- `src/rules/syntactic-patterns/lead-ins/private/discourse-evaluation.ts`
+- `src/rules/syntactic-patterns/lead-ins/generic-signposting.ts`
+- `src/rules/syntactic-patterns/closers/affirmation-closers.ts`
+- `src/rules/syntactic-patterns/contrast/private/negative-slop-frames.ts`
+- `src/rules/syntactic-patterns/contrast/private/negation-reframe-matcher.ts`
+- `src/rules/syntactic-patterns/contrast/private/policy-object.ts`
+- `src/rules/semantic-thinness/patterns/empty-quantification.json`
+- `src/rules/semantic-thinness/private/pattern-data-e.ts`
+- `behavior/fixtures/textlint-rules/cases/syntactic-patterns/hits.md`
+- `behavior/fixtures/textlint-rules/cases/syntactic-patterns/no-hits.md`
+- `behavior/fixtures/textlint-rules/cases/semantic-thinness/hits.md`
+- `behavior/fixtures/textlint-rules/cases/semantic-thinness/no-hits.md`
+- Fixture3 golden output for the changed suites after manual diff review

--- a/.plans/2026-07-21-160459-slop-pattern-expansion.md.spec.coverage.md
+++ b/.plans/2026-07-21-160459-slop-pattern-expansion.md.spec.coverage.md
@@ -1,0 +1,26 @@
+# Slop pattern expansion coverage
+
+## Goal
+
+- Fixture3 verifies every supplied slop class through public Slopless output.
+- Fixture3 verifies concrete literal and factual controls through the same public output.
+- Specular content blocks require the implementation markers and representative public cases.
+
+## Approach
+
+- Steps 1-5 map to Specular content blocks for `generic-signposting`, `affirmation-closers`, `negation-reframe`, and private direct-object parsing, plus the syntactic hit and no-hit Fixture3 suite.
+- Step 6 maps to the `empty-quantification` pattern content block, its pattern-data import, and the semantic-thinness hit and no-hit Fixture3 suite.
+- Step 7 maps to required fixture paths and exact representative fixture content.
+- Step 8 maps to Fixture3, repository validation, and the recorded full-corpus comparison against commit `09e10bc`.
+
+## Key decisions
+
+- Tree checks forbid separate modules for the supplied constructions.
+- Registry, `src/index.ts`, and `package.json` content checks forbid new public IDs or package exports for the private patterns.
+- Fixture3 owns runtime behavior, ranges, hit cases, and no-hit cases. Specular owns required source and fixture structure.
+- The typed dependency verifier rejects every non-relative import in changed implementation files, so the feature cannot add a package dependency through those modules.
+
+## Files to modify
+
+- Specular tree verification requires every implementation and fixture path listed by the plan.
+- Fixture3 golden files are generated approval output and therefore covered by the corresponding suites rather than fixed path checks.

--- a/.plans/2026-07-21-160459-slop-pattern-expansion.md.spec.json
+++ b/.plans/2026-07-21-160459-slop-pattern-expansion.md.spec.json
@@ -1,0 +1,193 @@
+{
+  "version": 4,
+  "requirements": {
+    "tree": {
+      "verifier": ["builtin:tree"],
+      "reason": "plan: files to modify and no new public rule modules",
+      "required": [
+        "src/rules/syntactic-patterns/lead-ins/private/discourse-evaluation.ts",
+        "src/rules/syntactic-patterns/lead-ins/generic-signposting.ts",
+        "src/rules/syntactic-patterns/closers/affirmation-closers.ts",
+        "src/rules/syntactic-patterns/contrast/private/negative-slop-frames.ts",
+        "src/rules/syntactic-patterns/contrast/private/negation-reframe-matcher.ts",
+        "src/rules/syntactic-patterns/contrast/private/policy-object.ts",
+        "src/rules/semantic-thinness/patterns/empty-quantification.json",
+        "src/rules/semantic-thinness/private/pattern-data-e.ts",
+        "behavior/fixtures/textlint-rules/cases/syntactic-patterns/hits.md",
+        "behavior/fixtures/textlint-rules/cases/syntactic-patterns/no-hits.md",
+        "behavior/fixtures/textlint-rules/cases/semantic-thinness/hits.md",
+        "behavior/fixtures/textlint-rules/cases/semantic-thinness/no-hits.md",
+        ".plans/2026-07-21-160459-slop-pattern-expansion.verify-imports.mjs"
+      ],
+      "forbidden": [
+        "src/rules/**/doing-real-work.ts",
+        "src/rules/**/load-bearing.ts",
+        "src/rules/**/empty-quantification.ts"
+      ]
+    },
+    "content": [
+      {
+        "verifier": ["builtin:content"],
+        "files": [
+          "src/rules/syntactic-patterns/lead-ins/private/discourse-evaluation.ts"
+        ],
+        "reason": "plan: generalized discourse-work, attention, and directional frames",
+        "required": [
+          "DISCOURSE_WORK_TAILS",
+          "matchWorthAttentionFrame",
+          "matchVagueFrameLocation",
+          "subject.at(-1)"
+        ]
+      },
+      {
+        "verifier": ["builtin:content"],
+        "files": [
+          "src/rules/syntactic-patterns/lead-ins/generic-signposting.ts"
+        ],
+        "reason": "plan: reuse generic-signposting and add the fun-part formula",
+        "required": [
+          "matchExpandedDiscourseFrame",
+          "the fun part is:"
+        ]
+      },
+      {
+        "verifier": ["builtin:content"],
+        "files": [
+          "src/rules/syntactic-patterns/closers/affirmation-closers.ts"
+        ],
+        "reason": "plan: reuse affirmation-closers for punctuation-independent good-stuff formulas",
+        "required": [
+          "that's the good stuff",
+          "that is the good stuff",
+          "withoutTerminalPunctuation"
+        ]
+      },
+      {
+        "verifier": ["builtin:content"],
+        "files": [
+          "src/rules/syntactic-patterns/contrast/private/negative-slop-frames.ts"
+        ],
+        "reason": "plan: constrain set replacements to direct abstract policy objects",
+        "required": [
+          "hasAbstractPolicyDirectObject",
+          "negatedActionSetReplacement"
+        ]
+      },
+      {
+        "verifier": ["builtin:content"],
+        "files": [
+          "src/rules/syntactic-patterns/contrast/private/policy-object.ts"
+        ],
+        "reason": "plan: parse the direct object of set before accepting an abstract policy noun",
+        "required": [
+          "ABSTRACT_POLICY_OBJECTS",
+          "POLICY_OBJECT_MODIFIERS",
+          "hasAbstractPolicyDirectObject"
+        ]
+      },
+      {
+        "verifier": ["builtin:content"],
+        "files": [
+          "src/rules/syntactic-patterns/contrast/private/negation-reframe-matcher.ts"
+        ],
+        "reason": "plan: colon completion belongs only to constrained set replacements",
+        "required": [
+          "hasAllowedReplacementColon",
+          "negatedActionSetReplacement"
+        ]
+      },
+      {
+        "verifier": ["builtin:content"],
+        "files": [
+          "src/rules/semantic-thinness/patterns/empty-quantification.json"
+        ],
+        "reason": "plan: private semantic pattern for vague quantification",
+        "required": [
+          "\"id\": \"empty-quantification\"",
+          "{minimizer} put a number on {deicticObject}."
+        ]
+      },
+      {
+        "verifier": ["builtin:content"],
+        "files": [
+          "behavior/fixtures/textlint-rules/cases/syntactic-patterns/hits.md"
+        ],
+        "reason": "plan: public hit behavior for every syntactic variant class",
+        "required": [
+          "The indexing layer is doing real work.",
+          "The kind layer is load-bearing.",
+          "The conclusion worth noticing is the shift in buyer intent.",
+          "The signal worth watching is the drop in indexed pages.",
+          "The result worth caring about is the qualified pipeline.",
+          "The real problem happens downstream.",
+          "The central answer lives here.",
+          "The fun part is: the index updates itself.",
+          "That's the good stuff!",
+          "The CMO did not add another review. She set a release condition:"
+        ]
+      },
+      {
+        "verifier": ["builtin:content"],
+        "files": [
+          "behavior/fixtures/textlint-rules/cases/syntactic-patterns/no-hits.md"
+        ],
+        "reason": "plan: literal and grammatical false-positive boundaries",
+        "required": [
+          "This wall is load-bearing.",
+          "The policy crew is doing real work on the compliance review.",
+          "She set a timer by policy:",
+          "She set one ruler on the rule:",
+          "The team did not add a review. The team moved:",
+          "She set the timer under policy:",
+          "She set a policy timer:"
+        ]
+      },
+      {
+        "verifier": ["builtin:content"],
+        "files": [
+          "behavior/fixtures/textlint-rules/cases/semantic-thinness/hits.md"
+        ],
+        "reason": "plan: all vague-quantification minimizers have public hit cases",
+        "required": [
+          "just put a number on it",
+          "simply put a number on that",
+          "merely put a number on this",
+          "basically put a number on that"
+        ]
+      },
+      {
+        "verifier": ["builtin:content"],
+        "files": [
+          "package.json",
+          "src/index.ts",
+          "src/registries/**/*.ts"
+        ],
+        "reason": "plan: no new public rule IDs or exports",
+        "forbidden": [
+          "empty-quantification",
+          "doing-real-work",
+          "load-bearing"
+        ]
+      }
+    ],
+    "dependencies": [
+      {
+        "verifier": [
+          "node",
+          ".plans/2026-07-21-160459-slop-pattern-expansion.verify-imports.mjs"
+        ],
+        "files": [
+          "src/rules/syntactic-patterns/lead-ins/private/discourse-evaluation.ts",
+          "src/rules/syntactic-patterns/lead-ins/generic-signposting.ts",
+          "src/rules/syntactic-patterns/closers/affirmation-closers.ts",
+          "src/rules/syntactic-patterns/contrast/private/negative-slop-frames.ts",
+          "src/rules/syntactic-patterns/contrast/private/negation-reframe-matcher.ts",
+          "src/rules/syntactic-patterns/contrast/private/policy-object.ts",
+          "src/rules/semantic-thinness/private/pattern-data-e.ts"
+        ],
+        "forbiddenGlobs": ["*"],
+        "reason": "plan: changed implementation files may use only relative imports and add no package dependency"
+      }
+    ]
+  }
+}

--- a/.plans/2026-07-21-160459-slop-pattern-expansion.md.spec.json
+++ b/.plans/2026-07-21-160459-slop-pattern-expansion.md.spec.json
@@ -104,6 +104,7 @@
         "reason": "plan: private semantic pattern for vague quantification",
         "required": [
           "\"id\": \"empty-quantification\"",
+          "\"matchMode\": \"suffix\"",
           "{minimizer} put a number on {deicticObject}."
         ]
       },
@@ -116,6 +117,8 @@
         "required": [
           "The indexing layer is doing real work.",
           "The kind layer is load-bearing.",
+          "The policy is load-bearing for the entire compliance program.",
+          "The policy is doing real work on the compliance review.",
           "The conclusion worth noticing is the shift in buyer intent.",
           "The signal worth watching is the drop in indexed pages.",
           "The result worth caring about is the qualified pipeline.",
@@ -123,7 +126,8 @@
           "The central answer lives here.",
           "The fun part is: the index updates itself.",
           "That's the good stuff!",
-          "The CMO did not add another review. She set a release condition:"
+          "The CMO did not add another review. She set a release condition:",
+          "The editor does not request another draft. She sets an approval threshold:"
         ]
       },
       {
@@ -139,7 +143,8 @@
           "She set one ruler on the rule:",
           "The team did not add a review. The team moved:",
           "She set the timer under policy:",
-          "She set a policy timer:"
+          "She set a policy timer:",
+          "The useful diagnosis starts upstream in the renal artery."
         ]
       },
       {
@@ -153,6 +158,17 @@
           "simply put a number on that",
           "merely put a number on this",
           "basically put a number on that"
+        ]
+      },
+      {
+        "verifier": ["builtin:content"],
+        "files": [
+          "behavior/fixtures/textlint-rules/cases/semantic-thinness/no-hits.md"
+        ],
+        "reason": "plan: measured and literal quantification continuations remain clean",
+        "required": [
+          "The report just put a number on it: 42%.",
+          "The report just put a number on it with a red marker."
         ]
       },
       {

--- a/.plans/2026-07-21-160459-slop-pattern-expansion.verify-imports.mjs
+++ b/.plans/2026-07-21-160459-slop-pattern-expansion.verify-imports.mjs
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+import ts from "typescript";
+
+const [specPath, category, blockIndexText] = process.argv.slice(2);
+const spec = JSON.parse(readFileSync(specPath, "utf8"));
+const block = spec.requirements[category][Number(blockIndexText)];
+const bareImports = [];
+
+function moduleSpecifier(node) {
+  if (ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) {
+    return node.moduleSpecifier;
+  }
+  if (
+    ts.isImportEqualsDeclaration(node) &&
+    ts.isExternalModuleReference(node.moduleReference)
+  ) {
+    return node.moduleReference.expression;
+  }
+  if (
+    ts.isCallExpression(node) &&
+    (node.expression.kind === ts.SyntaxKind.ImportKeyword ||
+      (ts.isIdentifier(node.expression) && node.expression.text === "require"))
+  ) {
+    return node.arguments[0];
+  }
+  return undefined;
+}
+
+for (const file of block.files) {
+  const source = readFileSync(file, "utf8");
+  const sourceFile = ts.createSourceFile(
+    file,
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS
+  );
+  const visit = (node) => {
+    const candidate = moduleSpecifier(node);
+    if (
+      candidate !== undefined &&
+      ts.isStringLiteral(candidate) &&
+      !candidate.text.startsWith(".")
+    ) {
+      bareImports.push(`${file}: ${candidate.text}`);
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+}
+
+for (const item of block.forbiddenGlobs) {
+  console.log(
+    JSON.stringify({
+      item,
+      status: bareImports.length === 0 ? "pass" : "fail",
+      ...(bareImports.length === 0
+        ? {}
+        : { message: `External imports found: ${bareImports.join(", ")}` })
+    })
+  );
+}

--- a/.worklogs/2026-07-02-142109-negation-surface-forms.md
+++ b/.worklogs/2026-07-02-142109-negation-surface-forms.md
@@ -1,0 +1,29 @@
+Summary:
+Extended negation-reframe detection across sloppy negator surface forms. The matcher now catches contracted copular negation, `never`, negative copular predicates such as `nobody`, and do-negated action reframes such as `doesn't replace... it depends...`.
+
+Decisions made:
+- Kept the public rule as `negation-reframe`; these are surface forms of the same construction, not a new rule family.
+- Added shared copular helpers for pronoun contractions such as `it's`, so pair matching does not rely on literal `it is`.
+- Used `findCopularNegation` as the pair signal for negative predicates like `nobody`, instead of treating `nothing` as the primary inline negation token. This restored existing `nothing ... not ...` inline hits.
+- Put negated action payoff logic into `negative-slop-frames.ts`, the existing negative pair-frame module, to keep the main matcher dependency count within the repository limit.
+- Added passive pronoun payoff guards for technical/reporting continuations such as `It is recorded` and `It was entered`.
+
+Verification:
+- Direct matcher probe catches the four requested forms:
+  `Indexing isn't... It's...`, `RAG doesn't replace... It depends...`, `It is never... It's...`, and `It was nobody... It was...`.
+- Direct matcher probe keeps factual/passive controls clean:
+  `RAG doesn't replace search because...`, `The outage is never sudden because... It is recorded...`, and `The witness was nobody important because... It was entered...`.
+- `fixture3 check --suite textlint-rules-cases-syntactic-patterns` differed, was reviewed, and approved.
+- `fixture3 check --feature textlint-rules` passed after the final code state.
+- `pnpm run validate` passed.
+
+Key files for context:
+- `src/rules/syntactic-patterns/contrast/private/negation-reframe-parts.ts`
+- `src/rules/syntactic-patterns/contrast/private/copular-reframe.ts`
+- `src/rules/syntactic-patterns/contrast/private/negative-slop-frames.ts`
+- `src/rules/syntactic-patterns/contrast/private/negation-reframe-matcher.ts`
+- `behavior/fixtures/textlint-rules/cases/syntactic-patterns/hits.md`
+- `behavior/fixtures/textlint-rules/cases/syntactic-patterns/no-hits.md`
+
+Next steps:
+- Release a patch version after review if this behavior is accepted.

--- a/.worklogs/2026-07-21-154527-negation-reframe-classification.md
+++ b/.worklogs/2026-07-21-154527-negation-reframe-classification.md
@@ -1,0 +1,27 @@
+# Negation reframe classification
+
+## Summary
+
+Replaced the blanket passive-definition exclusion with a pattern-specific classifier for sentence-pair negation reframes. The rule retains short and evaluative reframes while suppressing factual instructions, definitions, ownership relations, protocol references, numeric/name evidence paired with passive explanations, purpose statements, and causal provenance.
+
+## Decisions made
+
+- Kept action-payoff patterns independent from factual suppression because examples such as `RAG does not replace search. It depends on it.` are target behavior.
+- Applied classification to copular, explicit replacement, and explicit contrast-pivot paths so factual corrections cannot bypass it.
+- Required combined evidence for broad signals. A URL, number, name, passive verb, sentence length, or detailed clause does not suppress a finding alone.
+- Preserved framing nouns near the negation because `goal`, `fix`, `solution`, `problem`, and related nouns remain strong reframe signals even in detailed prose.
+- Added public hit and no-hit fixtures and reviewed every Fixture3 golden change before approval.
+
+## Key files for context
+
+- `.plans/2026-07-03-133106-negation-informativeness-gate.md`
+- `src/rules/syntactic-patterns/contrast/private/reframe-classification.ts`
+- `src/rules/syntactic-patterns/contrast/private/negation-reframe-matcher.ts`
+- `behavior/fixtures/textlint-rules/cases/syntactic-patterns/hits.md`
+- `behavior/fixtures/textlint-rules/cases/syntactic-patterns/no-hits.md`
+- `behavior/golden/textlint-rules-cases-syntactic-patterns/approved.normalized.json`
+
+## Next steps
+
+- The full public CLI took more than 30 minutes over the 20M-word human corpus because it runs every rule. The targeted changed-rule audit finished in under a minute. Investigate corpus-audit performance separately before relying on the full CLI for iterative rule analysis.
+- Continue using the human, suspected-AI, and generated-AI corpus comparison whenever the negation classifier boundary changes.

--- a/.worklogs/2026-07-21-171950-slop-pattern-expansion.md
+++ b/.worklogs/2026-07-21-171950-slop-pattern-expansion.md
@@ -1,0 +1,28 @@
+# Slop pattern expansion
+
+## Summary
+
+Extended existing syntactic rule owners for formulaic work claims, attention frames, vague directional frames, affirmation lines, and constrained negation replacements. Added one private semantic-thinness pattern for vague quantification, with expanded hit and adversarial no-hit fixtures.
+
+## Decisions made
+
+- Reused `generic-signposting`, `affirmation-closers`, and `negation-reframe`; no public rule ID was added.
+- Added `empty-quantification` under the existing semantic-thinness matcher because no existing private pattern represented `put a number on it`.
+- Restricted `doing real work` and `load-bearing` to known discourse-noun heads so literal crews and walls remain clean.
+- Restricted colon-ended negation replacements to `set` plus an abstract policy direct-object shape. Concrete objects followed by policy language remain clean.
+- Kept the old generic negated-action path unchanged after a corpus comparison exposed pronoun-index false positives.
+- Used Fixture3 for public behavior and Specular content, tree, export, and import-boundary checks.
+
+## Key files for context
+
+- `.plans/2026-07-21-160459-slop-pattern-expansion.md`
+- `src/rules/syntactic-patterns/lead-ins/private/discourse-evaluation.ts`
+- `src/rules/syntactic-patterns/contrast/private/policy-object.ts`
+- `src/rules/semantic-thinness/patterns/empty-quantification.json`
+- `behavior/fixtures/textlint-rules/cases/syntactic-patterns/hits.md`
+- `behavior/fixtures/textlint-rules/cases/syntactic-patterns/no-hits.md`
+
+## Next steps
+
+- Mine future supplied prose for additional discourse nouns and policy-object modifiers instead of widening the direct-object grammar without evidence.
+- Add new formulas to the same existing owners unless a behavior has no coherent current owner.

--- a/.worklogs/2026-07-21-175044-release-0.2.24.md
+++ b/.worklogs/2026-07-21-175044-release-0.2.24.md
@@ -1,0 +1,37 @@
+# Release 0.2.24
+
+## Summary
+
+Prepared the 0.2.24 release with broader negation-reframe, formulaic signposting, affirmation-closer, and empty-quantification detection.
+
+## Decisions made
+
+- Released as a patch because the update broadens existing rule behavior without changing the public API.
+- Based the release branch on `main` 0.2.23 and replayed only the three later development commits. This avoids duplicating earlier squashed fixture commits.
+- Used a clean worktree so the unrelated term-policy work in the development checkout remains uncommitted and excluded.
+
+## Key files for context
+
+- `package.json`
+- `src/rules/syntactic-patterns/contrast/private/negative-slop-frames.ts`
+- `src/rules/syntactic-patterns/lead-ins/private/discourse-evaluation.ts`
+- `src/rules/semantic-thinness/patterns/empty-quantification.json`
+- `behavior/fixtures/textlint-rules/cases/syntactic-patterns/hits.md`
+
+## Next steps
+
+- Run all validation and Fixture3 suites.
+- Merge the release pull request into `main`.
+- Publish GitHub release `v0.2.24`, verify npm publication and CI, then install the published version locally.
+
+## Verification issue
+
+- The `technical-terminology` suite stores an absolute source path in `filePath`, so the clean release worktree differs from its approved output only by checkout location. Removing `filePath` from both JSON files produces no diff. This runner path-stability bug needs a separate fix; the path-only difference was not approved.
+
+## Review corrections
+
+- Added a `suffix` template mode so empty quantification permits arbitrary subjects but rejects measured and literal continuations after the matched phrase.
+- Matched `is doing real work` and `is load-bearing` immediately after the linking verb, including longer sentence continuations.
+- Required vague locations such as `starts upstream` to end the sentence, preserving concrete locations such as `starts upstream in the renal artery`.
+- Accepted both `set` and `sets` in the constrained policy-object reframe.
+- Reviewed and approved only the two case-suite changes. After removing checkout-dependent `filePath` values, all 19 suites match their approved JSON.

--- a/behavior/fixtures/textlint-rules/cases/semantic-thinness/hits.md
+++ b/behavior/fixtures/textlint-rules/cases/semantic-thinness/hits.md
@@ -255,3 +255,11 @@ The path forward is obvious once the noise is no longer allowed to lead.
 The real opportunity is to let the work teach us what the work is.
 
 Everyone went quiet. Silence filled the yard.
+
+The analyst just put a number on it.
+
+The dashboard simply put a number on that.
+
+The report merely put a number on this.
+
+The review basically put a number on that.

--- a/behavior/fixtures/textlint-rules/cases/semantic-thinness/no-hits.md
+++ b/behavior/fixtures/textlint-rules/cases/semantic-thinness/no-hits.md
@@ -231,3 +231,9 @@ The conversation transcript says the speaker used the word clarity twice.
 Everyone went quiet because Marius raised one paw.
 
 Silence filled the yard after the sound meter stopped at 28 decibels.
+
+The teacher put number 12 on the sample label.
+
+The technician just put a number on it because the sample needed an anonymous label.
+
+The accountant simply put a number on invoice 4821.

--- a/behavior/fixtures/textlint-rules/cases/semantic-thinness/no-hits.md
+++ b/behavior/fixtures/textlint-rules/cases/semantic-thinness/no-hits.md
@@ -237,3 +237,7 @@ The teacher put number 12 on the sample label.
 The technician just put a number on it because the sample needed an anonymous label.
 
 The accountant simply put a number on invoice 4821.
+
+The report just put a number on it: 42%.
+
+The report just put a number on it with a red marker.

--- a/behavior/fixtures/textlint-rules/cases/syntactic-patterns/hits.md
+++ b/behavior/fixtures/textlint-rules/cases/syntactic-patterns/hits.md
@@ -1158,6 +1158,24 @@ No significant change from. No significant change from.
 
 Indexing isn't the boring technical step anymore. It's the gate everything else has to pass through.
 
+AI isn't generating throwaway suggestions. It's producing production-ready code that changes how the team ships.
+
+The audit trail is not a log. It's an immutable, queryable record of every decision the system makes.
+
+This is not a framework. It's a calibration layer that changes how every team evaluates the work.
+
+The goal is not to stay motivated. The goal is to build a system that works even when motivation disappears.
+
+The fix is not more self-hate. It is better structure around the moments when avoidance starts.
+
+Burnout is not a personal defect. It is often a mismatch between the demands of the job and the support around it.
+
+Notifications are not neutral. They are tiny attention thieves that fragment every hour of the day.
+
+Open Banking is not a regulation. It is a platform shift that changes who can build financial products.
+
+Leadership is not a title on an organization chart. It is defined by courage, judgment, and service under pressure.
+
 RAG doesn't replace search. It depends on it.
 
 It is never sudden. It's timely.

--- a/behavior/fixtures/textlint-rules/cases/syntactic-patterns/hits.md
+++ b/behavior/fixtures/textlint-rules/cases/syntactic-patterns/hits.md
@@ -1239,3 +1239,9 @@ The CMO did not add another review. She set one release threshold:
 That's the good stuff!
 
 That is the good stuff
+
+The policy is load-bearing for the entire compliance program.
+
+The policy is doing real work on the compliance review.
+
+The editor does not request another draft. She sets an approval threshold:

--- a/behavior/fixtures/textlint-rules/cases/syntactic-patterns/hits.md
+++ b/behavior/fixtures/textlint-rules/cases/syntactic-patterns/hits.md
@@ -1187,3 +1187,55 @@ Automation does not solve ownership. It moves it.
 Search doesn't create authority. It exposes it.
 
 Growth is never the point. It's the residue.
+
+The indexing layer is doing real work.
+
+The kind layer is load-bearing.
+
+The fun part is: the index updates itself.
+
+That's the good stuff.
+
+That is the good stuff.
+
+The CMO did not buy another dashboard. She set one launch rule:
+
+The team did not add another review. They set a release criterion:
+
+The shift worth paying attention to is the change in query mix.
+
+The result worth tracking is the pending queue.
+
+The useful diagnosis starts upstream:
+
+The practical audit begins earlier.
+
+The strategy is doing real work.
+
+The conclusion worth noticing is the shift in buyer intent.
+
+The signal worth watching is the drop in indexed pages.
+
+The result worth caring about is the qualified pipeline.
+
+The real problem happens downstream.
+
+The central answer lives here.
+
+The useful strategy starts there.
+
+The CMO did not add another review. She set a release condition:
+
+The CMO did not add another review. She set one launch policy:
+
+The CMO did not add another review. She set a deployment principle:
+
+The CMO did not add another review. She set one approval requirement:
+
+The CMO did not add another review. She set a quality standard:
+
+The CMO did not add another review. She set one release threshold:
+
+That's the good stuff!
+
+That is the good stuff

--- a/behavior/fixtures/textlint-rules/cases/syntactic-patterns/hits.md
+++ b/behavior/fixtures/textlint-rules/cases/syntactic-patterns/hits.md
@@ -1155,3 +1155,17 @@ No conflict. No antagonist.
 No change. No change.
 
 No significant change from. No significant change from.
+
+Indexing isn't the boring technical step anymore. It's the gate everything else has to pass through.
+
+RAG doesn't replace search. It depends on it.
+
+It is never sudden. It's timely.
+
+It was nobody important. It was a guest.
+
+Automation does not solve ownership. It moves it.
+
+Search doesn't create authority. It exposes it.
+
+Growth is never the point. It's the residue.

--- a/behavior/fixtures/textlint-rules/cases/syntactic-patterns/no-hits.md
+++ b/behavior/fixtures/textlint-rules/cases/syntactic-patterns/no-hits.md
@@ -289,3 +289,53 @@ A byte is not a decimal digit used in computing. It is a unit of digital informa
 The source code is not company property under this agreement. It is the property of the individual contractor.
 
 The material is not manufactured from petroleum in this process. It is derived from recycled cellulose.
+
+The masonry crew is doing real work on the east wall.
+
+The retaining wall is load-bearing.
+
+This wall is load-bearing.
+
+The fun part is scheduled for Saturday afternoon.
+
+That's the good stuff I ordered from the supplier.
+
+The CMO did not buy another dashboard because procurement rejected it. She set one launch rule:
+
+The carpenter did not buy another dashboard. She set one ruler on the bench:
+
+The shift worth paying attention to begins at 09:00 in the east ward.
+
+The patient worth paying attention to is waiting beside room 14.
+
+The useful diagnosis names iron deficiency after ferritin testing.
+
+The practical audit begins with crawl logs from the April export.
+
+The young man did not dispute it and took the money. He looked at the old woman.
+
+And she did not. She walked between two men.
+
+The captain said he did not believe in it. He said he reckoned the barrel gained on us because it was in a better current.
+
+Though the canals did not drain, the purchase primed Florida's economy. It made news and attracted buyers.
+
+Jones said the game does not look good in screenshots. They took two steps to improve its presentation.
+
+The policy crew is doing real work on the compliance review.
+
+The CMO did not buy another dashboard. She set a timer by policy:
+
+The CMO did not buy another dashboard. She set one ruler on the rule:
+
+The team did not add a review. The team moved:
+
+The CMO did not buy another dashboard. She set the timer under policy:
+
+The CMO did not buy another dashboard. She set a timer near policy:
+
+The CMO did not buy another dashboard. She set a marker beside policy:
+
+The CMO did not buy another dashboard. She set a policy timer:
+
+The CMO did not buy another dashboard. She set a launch policy timer:

--- a/behavior/fixtures/textlint-rules/cases/syntactic-patterns/no-hits.md
+++ b/behavior/fixtures/textlint-rules/cases/syntactic-patterns/no-hits.md
@@ -339,3 +339,5 @@ The CMO did not buy another dashboard. She set a marker beside policy:
 The CMO did not buy another dashboard. She set a policy timer:
 
 The CMO did not buy another dashboard. She set a launch policy timer:
+
+The useful diagnosis starts upstream in the renal artery.

--- a/behavior/fixtures/textlint-rules/cases/syntactic-patterns/no-hits.md
+++ b/behavior/fixtures/textlint-rules/cases/syntactic-patterns/no-hits.md
@@ -255,3 +255,37 @@ The adapter does not replace the cache because the deployment reuses the same ke
 The outage is never sudden because the monitor reports latency first. It is recorded in the incident log.
 
 The witness was nobody important because the court record used a pseudonym. It was entered as exhibit B.
+
+Application data is never sent in DTLS record-layer application_data packets. Rather, complete RTP or RTCP packets are passed to the DTLS stack.
+
+The flights were never paid, and Jennings and Allsup continued the tour for two more weeks. They were paid less than half of the original agreed salary.
+
+But condoms alone aren't the most effective form of birth control. It's safest to use condoms with another form of birth control.
+
+Aphasia is not a disease. It's a symptom of damage to the parts of the brain that control language.
+
+The bank does not own 80% of your home. Instead they have lent you some amount of money, and they have a lien.
+
+HTML is not a programming language. It is a markup language used to organize and display content on a webpage.
+
+Photosynthesis does not require light during the Calvin cycle. Instead, it uses energy products created in the light-dependent reactions.
+
+The protocol is not merely a vendor convention. It is defined by RFC 8446 and implemented by OpenSSL.
+
+The diagnosis is not just a descriptive label. It is classified by ICD-11 under code 6A70.
+
+The service is not limited to one port. It listens on ports 80 and 443.
+
+The itinerary is not limited to France. It also includes Germany and Italy.
+
+The account is not owned by the company. It is owned by the employee.
+
+KS is not inherited. It's caused by a random error that happens when a sperm or egg is formed.
+
+JSON is not executable code in a web browser. It is intended for data interchange between systems.
+
+A byte is not a decimal digit used in computing. It is a unit of digital information.
+
+The source code is not company property under this agreement. It is the property of the individual contractor.
+
+The material is not manufactured from petroleum in this process. It is derived from recycled cellulose.

--- a/behavior/fixtures/textlint-rules/cases/syntactic-patterns/no-hits.md
+++ b/behavior/fixtures/textlint-rules/cases/syntactic-patterns/no-hits.md
@@ -247,3 +247,11 @@ No parking is allowed after midnight. No smoking is allowed indoors.
 No reviewer signed the memo because the deadline moved. No owner changed the queue because the patch passed.
 
 No index was missing, so the migration passed.
+
+RAG doesn't replace search because the endpoint still queries Lucene.
+
+The adapter does not replace the cache because the deployment reuses the same key.
+
+The outage is never sudden because the monitor reports latency first. It is recorded in the incident log.
+
+The witness was nobody important because the court record used a pseudonym. It was entered as exhibit B.

--- a/behavior/golden/textlint-rules-cases-semantic-thinness/approved.meta.json
+++ b/behavior/golden/textlint-rules-cases-semantic-thinness/approved.meta.json
@@ -1,23 +1,23 @@
 {
   "suite": "textlint-rules-cases-semantic-thinness",
   "kind": "approved",
-  "run_id": "2026-06-01T18-07-00.393627Z-04547efb",
-  "run_commit": "91e1c83",
+  "run_id": "2026-07-21T16-02-27.233681Z-04547efb",
+  "run_commit": "09e10bc",
   "working_tree": "dirty",
-  "recorded_at": "2026-06-01T18:07:00.393627Z",
-  "fixture_hash": "sha256:160c5d2039408623301f14622b8794aff564f95666af4f2c65c9b6377ba15430",
+  "recorded_at": "2026-07-21T16:02:27.233681Z",
+  "fixture_hash": "sha256:3843f2858e7b905012ea4d6901d793a076f7448fe4ed01585d020948fe0d067c",
   "manifest_hash": "sha256:04547efbb13157ee3d8ef18dda767231fd63d3f9cc27c15317cf28c5f0583e7b",
   "tool_version": "0.1.8",
   "output_schema_version": "1",
   "fixtures": [
     {
       "path": "behavior/fixtures/textlint-rules/cases/semantic-thinness/hits.md",
-      "sha256": "sha256:6a815200233d2c26a33644e3689fb76e5cd3c933eb2512804268f10166339ccd"
+      "sha256": "sha256:39dd7d15ab5f126e92414c9823fde60821bf56d557a6784e3a164fc1da73a2db"
     },
     {
       "path": "behavior/fixtures/textlint-rules/cases/semantic-thinness/no-hits.md",
-      "sha256": "sha256:36f23dd4883462dae296b5aa16a3e26da44365d7cd3d75011ad91c7febf81793"
+      "sha256": "sha256:cd080c5dd4883cf119f779c0dfd66d545f112e440279687e40b5599e76ecfb3f"
     }
   ],
-  "comment": "antislop-gap signals: corporate-speak hype terms (world-class/next-level/supercharge/north-star/table-stakes), cliches 'stands as a testament to', boilerplate-framing honesty/throat-clearing openers; dropped redundant 'best-in-class solution'"
+  "comment": "Add reviewed basically-minimizer coverage for empty quantification."
 }

--- a/behavior/golden/textlint-rules-cases-semantic-thinness/approved.meta.json
+++ b/behavior/golden/textlint-rules-cases-semantic-thinness/approved.meta.json
@@ -1,11 +1,11 @@
 {
   "suite": "textlint-rules-cases-semantic-thinness",
   "kind": "approved",
-  "run_id": "2026-07-21T16-02-27.233681Z-04547efb",
-  "run_commit": "09e10bc",
+  "run_id": "2026-07-21T17-01-01.34411Z-04547efb",
+  "run_commit": "7c71e7f",
   "working_tree": "dirty",
-  "recorded_at": "2026-07-21T16:02:27.233681Z",
-  "fixture_hash": "sha256:3843f2858e7b905012ea4d6901d793a076f7448fe4ed01585d020948fe0d067c",
+  "recorded_at": "2026-07-21T17:01:01.34411Z",
+  "fixture_hash": "sha256:faca98810a74259a2e831529985a327903a0b58416ab2c217d5b7329871b14ca",
   "manifest_hash": "sha256:04547efbb13157ee3d8ef18dda767231fd63d3f9cc27c15317cf28c5f0583e7b",
   "tool_version": "0.1.8",
   "output_schema_version": "1",
@@ -16,8 +16,8 @@
     },
     {
       "path": "behavior/fixtures/textlint-rules/cases/semantic-thinness/no-hits.md",
-      "sha256": "sha256:cd080c5dd4883cf119f779c0dfd66d545f112e440279687e40b5599e76ecfb3f"
+      "sha256": "sha256:b53962b46adbb9c2f3748b95a0e003443851e1ab311f5be6ba77c57bbbda9ed8"
     }
   ],
-  "comment": "Add reviewed basically-minimizer coverage for empty quantification."
+  "comment": "Review blockers fixed: suffix quantification, continued work frames, concrete location guard, and sets form"
 }

--- a/behavior/golden/textlint-rules-cases-semantic-thinness/approved.normalized.json
+++ b/behavior/golden/textlint-rules-cases-semantic-thinness/approved.normalized.json
@@ -3563,7 +3563,7 @@
             "line": 1
           }
         },
-        "message": "Coleman-Liau is 13.37. Keep it at 12 or lower.",
+        "message": "Coleman-Liau is 13.26. Keep it at 12 or lower.",
         "range": [
           0,
           1
@@ -3586,7 +3586,7 @@
             "line": 1
           }
         },
-        "message": "Flesch Reading Ease is -1236.53. Keep it at 61 or higher.",
+        "message": "Flesch Reading Ease is -1257.84. Keep it at 61 or higher.",
         "range": [
           0,
           1
@@ -3609,7 +3609,7 @@
             "line": 1
           }
         },
-        "message": "Gunning Fog is 521.14. Keep it at 12 or lower.",
+        "message": "Gunning Fog is 529.51. Keep it at 12 or lower.",
         "range": [
           0,
           1

--- a/behavior/golden/textlint-rules-cases-semantic-thinness/approved.normalized.json
+++ b/behavior/golden/textlint-rules-cases-semantic-thinness/approved.normalized.json
@@ -16,7 +16,7 @@
             "line": 1
           }
         },
-        "message": "Coleman-Liau is 12.68. Keep it at 12 or lower.",
+        "message": "Coleman-Liau is 12.56. Keep it at 12 or lower.",
         "range": [
           0,
           1
@@ -39,7 +39,7 @@
             "line": 1
           }
         },
-        "message": "Flesch Reading Ease is -257.77. Keep it at 61 or higher.",
+        "message": "Flesch Reading Ease is -268.52. Keep it at 61 or higher.",
         "range": [
           0,
           1
@@ -62,7 +62,7 @@
             "line": 1
           }
         },
-        "message": "Gunning Fog is 135.73. Keep it at 12 or lower.",
+        "message": "Gunning Fog is 139.96. Keep it at 12 or lower.",
         "range": [
           0,
           1
@@ -3451,6 +3451,98 @@
         "ruleId": "semantic-thinness",
         "severity": 2,
         "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 5920,
+        "line": 259,
+        "loc": {
+          "end": {
+            "column": 37,
+            "line": 259
+          },
+          "start": {
+            "column": 1,
+            "line": 259
+          }
+        },
+        "message": "Semantic thinness (empty-quantification): Catch claims that minimize an unexplained act of quantification instead of naming the metric, measurement, or result. Matched template: {minimizer} put a number on {deicticObject}.",
+        "range": [
+          5920,
+          5956
+        ],
+        "ruleId": "semantic-thinness",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 5958,
+        "line": 261,
+        "loc": {
+          "end": {
+            "column": 43,
+            "line": 261
+          },
+          "start": {
+            "column": 1,
+            "line": 261
+          }
+        },
+        "message": "Semantic thinness (empty-quantification): Catch claims that minimize an unexplained act of quantification instead of naming the metric, measurement, or result. Matched template: {minimizer} put a number on {deicticObject}.",
+        "range": [
+          5958,
+          6000
+        ],
+        "ruleId": "semantic-thinness",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 6002,
+        "line": 263,
+        "loc": {
+          "end": {
+            "column": 40,
+            "line": 263
+          },
+          "start": {
+            "column": 1,
+            "line": 263
+          }
+        },
+        "message": "Semantic thinness (empty-quantification): Catch claims that minimize an unexplained act of quantification instead of naming the metric, measurement, or result. Matched template: {minimizer} put a number on {deicticObject}.",
+        "range": [
+          6002,
+          6041
+        ],
+        "ruleId": "semantic-thinness",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 6043,
+        "line": 265,
+        "loc": {
+          "end": {
+            "column": 43,
+            "line": 265
+          },
+          "start": {
+            "column": 1,
+            "line": 265
+          }
+        },
+        "message": "Semantic thinness (empty-quantification): Catch claims that minimize an unexplained act of quantification instead of naming the metric, measurement, or result. Matched template: {minimizer} put a number on {deicticObject}.",
+        "range": [
+          6043,
+          6085
+        ],
+        "ruleId": "semantic-thinness",
+        "severity": 2,
+        "type": "lint"
       }
     ]
   },
@@ -3471,7 +3563,7 @@
             "line": 1
           }
         },
-        "message": "Coleman-Liau is 13.43. Keep it at 12 or lower.",
+        "message": "Coleman-Liau is 13.37. Keep it at 12 or lower.",
         "range": [
           0,
           1
@@ -3494,7 +3586,7 @@
             "line": 1
           }
         },
-        "message": "Flesch Reading Ease is -1203.03. Keep it at 61 or higher.",
+        "message": "Flesch Reading Ease is -1236.53. Keep it at 61 or higher.",
         "range": [
           0,
           1
@@ -3517,7 +3609,7 @@
             "line": 1
           }
         },
-        "message": "Gunning Fog is 507.91. Keep it at 12 or lower.",
+        "message": "Gunning Fog is 521.14. Keep it at 12 or lower.",
         "range": [
           0,
           1

--- a/behavior/golden/textlint-rules-cases-syntactic-patterns/approved.meta.json
+++ b/behavior/golden/textlint-rules-cases-syntactic-patterns/approved.meta.json
@@ -1,27 +1,27 @@
 {
   "suite": "textlint-rules-cases-syntactic-patterns",
   "kind": "approved",
-  "run_id": "2026-07-21T14-43-01.409763Z-04547efb",
-  "run_commit": "b8eb45e",
+  "run_id": "2026-07-21T16-12-54.044442Z-04547efb",
+  "run_commit": "09e10bc",
   "working_tree": "dirty",
-  "recorded_at": "2026-07-21T14:43:01.409763Z",
-  "fixture_hash": "sha256:44712e16a1154e353f2e85a50dbf6d45ae6d50eb31588b4f506a7c90bca35128",
+  "recorded_at": "2026-07-21T16:12:54.044442Z",
+  "fixture_hash": "sha256:3d14fe4f98786b3e64373cb11b90f8c7462b631b2ad56e07c93345c118619a04",
   "manifest_hash": "sha256:04547efbb13157ee3d8ef18dda767231fd63d3f9cc27c15317cf28c5f0583e7b",
   "tool_version": "0.1.8",
   "output_schema_version": "1",
   "fixtures": [
     {
       "path": "behavior/fixtures/textlint-rules/cases/syntactic-patterns/hits.md",
-      "sha256": "sha256:5a9f0f21c694e00e9d340cf84ad753d9a2dd33bda787f6a7da198c8836953cc2"
+      "sha256": "sha256:3f56cf46c2e41bd5a8c846ee4a23bdd7a9239f5b0133bb02adf7dc9b3be943bf"
     },
     {
       "path": "behavior/fixtures/textlint-rules/cases/syntactic-patterns/no-hits.md",
-      "sha256": "sha256:9f3993dc2221126867ec53f305c3fa4ec6bcae27c198063280e827ecde363250"
+      "sha256": "sha256:2a8d6132eeac57e1d36e41ff5d5d19f4849723cf2ec28ec80224a1416557febf"
     },
     {
       "path": "behavior/fixtures/textlint-rules/cases/syntactic-patterns/significance-density.md",
       "sha256": "sha256:a5489177104e3714ea3558c1d90bdd91573bf719c83112225ae9e9b0e288c6da"
     }
   ],
-  "comment": "Reviewed final negation classifier fixtures. Four factual relation no-hits add only the expected three aggregate readability-score changes; all new hits report and no negation no-hit reports."
+  "comment": "Add object-head adversarial controls; policy must be the final recognized direct-object head."
 }

--- a/behavior/golden/textlint-rules-cases-syntactic-patterns/approved.meta.json
+++ b/behavior/golden/textlint-rules-cases-syntactic-patterns/approved.meta.json
@@ -1,27 +1,27 @@
 {
   "suite": "textlint-rules-cases-syntactic-patterns",
   "kind": "approved",
-  "run_id": "2026-07-21T16-12-54.044442Z-04547efb",
-  "run_commit": "09e10bc",
+  "run_id": "2026-07-21T17-01-13.198739Z-04547efb",
+  "run_commit": "7c71e7f",
   "working_tree": "dirty",
-  "recorded_at": "2026-07-21T16:12:54.044442Z",
-  "fixture_hash": "sha256:3d14fe4f98786b3e64373cb11b90f8c7462b631b2ad56e07c93345c118619a04",
+  "recorded_at": "2026-07-21T17:01:13.198739Z",
+  "fixture_hash": "sha256:525baf9cdab5b0b94b854727105cb711be43b9823919522ddbd52d1581732ea6",
   "manifest_hash": "sha256:04547efbb13157ee3d8ef18dda767231fd63d3f9cc27c15317cf28c5f0583e7b",
   "tool_version": "0.1.8",
   "output_schema_version": "1",
   "fixtures": [
     {
       "path": "behavior/fixtures/textlint-rules/cases/syntactic-patterns/hits.md",
-      "sha256": "sha256:3f56cf46c2e41bd5a8c846ee4a23bdd7a9239f5b0133bb02adf7dc9b3be943bf"
+      "sha256": "sha256:21c0f2d0b3f5f22f9e6e7781ce15f17349e7d3998e6322cd615d424b1120b5bd"
     },
     {
       "path": "behavior/fixtures/textlint-rules/cases/syntactic-patterns/no-hits.md",
-      "sha256": "sha256:2a8d6132eeac57e1d36e41ff5d5d19f4849723cf2ec28ec80224a1416557febf"
+      "sha256": "sha256:d6691e836308db0c37bc4ab0ce1502f12ead3a638581216cee043027405cdead"
     },
     {
       "path": "behavior/fixtures/textlint-rules/cases/syntactic-patterns/significance-density.md",
       "sha256": "sha256:a5489177104e3714ea3558c1d90bdd91573bf719c83112225ae9e9b0e288c6da"
     }
   ],
-  "comment": "Add object-head adversarial controls; policy must be the final recognized direct-object head."
+  "comment": "Review blockers fixed: suffix quantification, continued work frames, concrete location guard, and sets form"
 }

--- a/behavior/golden/textlint-rules-cases-syntactic-patterns/approved.meta.json
+++ b/behavior/golden/textlint-rules-cases-syntactic-patterns/approved.meta.json
@@ -1,27 +1,27 @@
 {
   "suite": "textlint-rules-cases-syntactic-patterns",
   "kind": "approved",
-  "run_id": "2026-07-02T13-32-19.767707Z-04547efb",
-  "run_commit": "024fc80",
+  "run_id": "2026-07-21T14-43-01.409763Z-04547efb",
+  "run_commit": "b8eb45e",
   "working_tree": "dirty",
-  "recorded_at": "2026-07-02T13:32:19.767707Z",
-  "fixture_hash": "sha256:599a30677e51cbbc1a83099b2ff10988d3059e815b128aab91c938bfc9c51337",
+  "recorded_at": "2026-07-21T14:43:01.409763Z",
+  "fixture_hash": "sha256:44712e16a1154e353f2e85a50dbf6d45ae6d50eb31588b4f506a7c90bca35128",
   "manifest_hash": "sha256:04547efbb13157ee3d8ef18dda767231fd63d3f9cc27c15317cf28c5f0583e7b",
   "tool_version": "0.1.8",
   "output_schema_version": "1",
   "fixtures": [
     {
       "path": "behavior/fixtures/textlint-rules/cases/syntactic-patterns/hits.md",
-      "sha256": "sha256:e1c3e694c48f0c44a6023f3adc874764f9bcaac6172af3345bf4f58628e33315"
+      "sha256": "sha256:5a9f0f21c694e00e9d340cf84ad753d9a2dd33bda787f6a7da198c8836953cc2"
     },
     {
       "path": "behavior/fixtures/textlint-rules/cases/syntactic-patterns/no-hits.md",
-      "sha256": "sha256:450a66687c61f6f03ce424287a456f995c18e02963c5c820b94867649c7ce707"
+      "sha256": "sha256:9f3993dc2221126867ec53f305c3fa4ec6bcae27c198063280e827ecde363250"
     },
     {
       "path": "behavior/fixtures/textlint-rules/cases/syntactic-patterns/significance-density.md",
       "sha256": "sha256:a5489177104e3714ea3558c1d90bdd91573bf719c83112225ae9e9b0e288c6da"
     }
   ],
-  "comment": "Extend negation reframe surface forms"
+  "comment": "Reviewed final negation classifier fixtures. Four factual relation no-hits add only the expected three aggregate readability-score changes; all new hits report and no negation no-hit reports."
 }

--- a/behavior/golden/textlint-rules-cases-syntactic-patterns/approved.meta.json
+++ b/behavior/golden/textlint-rules-cases-syntactic-patterns/approved.meta.json
@@ -1,27 +1,27 @@
 {
   "suite": "textlint-rules-cases-syntactic-patterns",
   "kind": "approved",
-  "run_id": "2026-07-01T10-54-56.839376Z-04547efb",
-  "run_commit": "22d9e98",
+  "run_id": "2026-07-02T13-32-19.767707Z-04547efb",
+  "run_commit": "024fc80",
   "working_tree": "dirty",
-  "recorded_at": "2026-07-01T10:54:56.839376Z",
-  "fixture_hash": "sha256:bd02fc4e6ebe83a2478be75155b5a7206cc558feda9e7c3e2b8d07dc5601ed28",
+  "recorded_at": "2026-07-02T13:32:19.767707Z",
+  "fixture_hash": "sha256:599a30677e51cbbc1a83099b2ff10988d3059e815b128aab91c938bfc9c51337",
   "manifest_hash": "sha256:04547efbb13157ee3d8ef18dda767231fd63d3f9cc27c15317cf28c5f0583e7b",
   "tool_version": "0.1.8",
   "output_schema_version": "1",
   "fixtures": [
     {
       "path": "behavior/fixtures/textlint-rules/cases/syntactic-patterns/hits.md",
-      "sha256": "sha256:50443cb1cca2d69481402e207cefc6a0572d3b0c494012fd51ee53e9fb05e799"
+      "sha256": "sha256:e1c3e694c48f0c44a6023f3adc874764f9bcaac6172af3345bf4f58628e33315"
     },
     {
       "path": "behavior/fixtures/textlint-rules/cases/syntactic-patterns/no-hits.md",
-      "sha256": "sha256:d713f7ae23482b676cefeffbc2728e71732c3a05eee2eea01f25bd22ba390ac6"
+      "sha256": "sha256:450a66687c61f6f03ce424287a456f995c18e02963c5c820b94867649c7ce707"
     },
     {
       "path": "behavior/fixtures/textlint-rules/cases/syntactic-patterns/significance-density.md",
       "sha256": "sha256:a5489177104e3714ea3558c1d90bdd91573bf719c83112225ae9e9b0e288c6da"
     }
   ],
-  "comment": "Flag duplicate no-fragment pairs"
+  "comment": "Extend negation reframe surface forms"
 }

--- a/behavior/golden/textlint-rules-cases-syntactic-patterns/approved.normalized.json
+++ b/behavior/golden/textlint-rules-cases-syntactic-patterns/approved.normalized.json
@@ -16,7 +16,7 @@
             "line": 1
           }
         },
-        "message": "Flesch Reading Ease is 48.27. Keep it at 61 or higher.",
+        "message": "Flesch Reading Ease is 48.37. Keep it at 61 or higher.",
         "range": [
           0,
           1
@@ -39,7 +39,7 @@
             "line": 1
           }
         },
-        "message": "Gunning Fog is 14.92. Keep it at 12 or lower.",
+        "message": "Gunning Fog is 14.85. Keep it at 12 or lower.",
         "range": [
           0,
           1
@@ -13870,6 +13870,696 @@
         "ruleId": "negation-reframe",
         "severity": 2,
         "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 52856,
+        "line": 1191,
+        "loc": {
+          "end": {
+            "column": 39,
+            "line": 1191
+          },
+          "start": {
+            "column": 1,
+            "line": 1191
+          }
+        },
+        "message": "Generic signposting found: is-doing-real-work. Replace the frame with the concrete claim.",
+        "range": [
+          52856,
+          52894
+        ],
+        "ruleId": "generic-signposting",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 52896,
+        "line": 1193,
+        "loc": {
+          "end": {
+            "column": 32,
+            "line": 1193
+          },
+          "start": {
+            "column": 1,
+            "line": 1193
+          }
+        },
+        "message": "Generic signposting found: is-load-bearing. Replace the frame with the concrete claim.",
+        "range": [
+          52896,
+          52927
+        ],
+        "ruleId": "generic-signposting",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 52929,
+        "line": 1195,
+        "loc": {
+          "end": {
+            "column": 43,
+            "line": 1195
+          },
+          "start": {
+            "column": 1,
+            "line": 1195
+          }
+        },
+        "message": "Demonstrative emphasis found: \"The fun part is: the index updates itself.\". Reduce repeated short emphasis lines.",
+        "range": [
+          52929,
+          52971
+        ],
+        "ruleId": "demonstrative-emphasis",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 52929,
+        "line": 1195,
+        "loc": {
+          "end": {
+            "column": 43,
+            "line": 1195
+          },
+          "start": {
+            "column": 1,
+            "line": 1195
+          }
+        },
+        "message": "Generic signposting found: the fun part is:. Replace the frame with the concrete claim.",
+        "range": [
+          52929,
+          52971
+        ],
+        "ruleId": "generic-signposting",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 52973,
+        "line": 1197,
+        "loc": {
+          "end": {
+            "column": 23,
+            "line": 1197
+          },
+          "start": {
+            "column": 1,
+            "line": 1197
+          }
+        },
+        "message": "Formula affirmation found: \"That's the good stuff.\". Replace the empty formula line with substance.",
+        "range": [
+          52973,
+          52995
+        ],
+        "ruleId": "affirmation-closers",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 52997,
+        "line": 1199,
+        "loc": {
+          "end": {
+            "column": 24,
+            "line": 1199
+          },
+          "start": {
+            "column": 1,
+            "line": 1199
+          }
+        },
+        "message": "Formula affirmation found: \"That is the good stuff.\". Replace the empty formula line with substance.",
+        "range": [
+          52997,
+          53020
+        ],
+        "ruleId": "affirmation-closers",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 53022,
+        "line": 1201,
+        "loc": {
+          "end": {
+            "column": 64,
+            "line": 1201
+          },
+          "start": {
+            "column": 1,
+            "line": 1201
+          }
+        },
+        "message": "Negation reframe found: \"The CMO did not buy another dashboard. She set one launch rule:\". Rewrite without the not-X-then-Y construction.",
+        "range": [
+          53022,
+          53085
+        ],
+        "ruleId": "negation-reframe",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 53087,
+        "line": 1203,
+        "loc": {
+          "end": {
+            "column": 67,
+            "line": 1203
+          },
+          "start": {
+            "column": 1,
+            "line": 1203
+          }
+        },
+        "message": "Negation reframe found: \"The team did not add another review. They set a release criterion:\". Rewrite without the not-X-then-Y construction.",
+        "range": [
+          53087,
+          53153
+        ],
+        "ruleId": "negation-reframe",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 53155,
+        "line": 1205,
+        "loc": {
+          "end": {
+            "column": 64,
+            "line": 1205
+          },
+          "start": {
+            "column": 1,
+            "line": 1205
+          }
+        },
+        "message": "Generic signposting found: the-shift-worth-attention. Replace the frame with the concrete claim.",
+        "range": [
+          53155,
+          53218
+        ],
+        "ruleId": "generic-signposting",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 53220,
+        "line": 1207,
+        "loc": {
+          "end": {
+            "column": 48,
+            "line": 1207
+          },
+          "start": {
+            "column": 1,
+            "line": 1207
+          }
+        },
+        "message": "Demonstrative emphasis found: \"The result worth tracking is the pending queue.\". Reduce repeated short emphasis lines.",
+        "range": [
+          53220,
+          53267
+        ],
+        "ruleId": "demonstrative-emphasis",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 53220,
+        "line": 1207,
+        "loc": {
+          "end": {
+            "column": 48,
+            "line": 1207
+          },
+          "start": {
+            "column": 1,
+            "line": 1207
+          }
+        },
+        "message": "Generic signposting found: the-result-worth-attention. Replace the frame with the concrete claim.",
+        "range": [
+          53220,
+          53267
+        ],
+        "ruleId": "generic-signposting",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 53269,
+        "line": 1209,
+        "loc": {
+          "end": {
+            "column": 38,
+            "line": 1209
+          },
+          "start": {
+            "column": 1,
+            "line": 1209
+          }
+        },
+        "message": "Generic signposting found: the-useful-diagnosis-starts-upstream. Replace the frame with the concrete claim.",
+        "range": [
+          53269,
+          53306
+        ],
+        "ruleId": "generic-signposting",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 53308,
+        "line": 1211,
+        "loc": {
+          "end": {
+            "column": 36,
+            "line": 1211
+          },
+          "start": {
+            "column": 1,
+            "line": 1211
+          }
+        },
+        "message": "Generic signposting found: the-practical-audit-begins-earlier. Replace the frame with the concrete claim.",
+        "range": [
+          53308,
+          53343
+        ],
+        "ruleId": "generic-signposting",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 53345,
+        "line": 1213,
+        "loc": {
+          "end": {
+            "column": 33,
+            "line": 1213
+          },
+          "start": {
+            "column": 1,
+            "line": 1213
+          }
+        },
+        "message": "Generic signposting found: is-doing-real-work. Replace the frame with the concrete claim.",
+        "range": [
+          53345,
+          53377
+        ],
+        "ruleId": "generic-signposting",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 53379,
+        "line": 1215,
+        "loc": {
+          "end": {
+            "column": 60,
+            "line": 1215
+          },
+          "start": {
+            "column": 1,
+            "line": 1215
+          }
+        },
+        "message": "Demonstrative emphasis found: \"The conclusion worth noticing is the shift in buyer intent.\". Reduce repeated short emphasis lines.",
+        "range": [
+          53379,
+          53438
+        ],
+        "ruleId": "demonstrative-emphasis",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 53379,
+        "line": 1215,
+        "loc": {
+          "end": {
+            "column": 60,
+            "line": 1215
+          },
+          "start": {
+            "column": 1,
+            "line": 1215
+          }
+        },
+        "message": "Generic signposting found: the-conclusion-worth-attention. Replace the frame with the concrete claim.",
+        "range": [
+          53379,
+          53438
+        ],
+        "ruleId": "generic-signposting",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 53440,
+        "line": 1217,
+        "loc": {
+          "end": {
+            "column": 56,
+            "line": 1217
+          },
+          "start": {
+            "column": 1,
+            "line": 1217
+          }
+        },
+        "message": "Demonstrative emphasis found: \"The signal worth watching is the drop in indexed pages.\". Reduce repeated short emphasis lines.",
+        "range": [
+          53440,
+          53495
+        ],
+        "ruleId": "demonstrative-emphasis",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 53440,
+        "line": 1217,
+        "loc": {
+          "end": {
+            "column": 56,
+            "line": 1217
+          },
+          "start": {
+            "column": 1,
+            "line": 1217
+          }
+        },
+        "message": "Generic signposting found: the-signal-worth-attention. Replace the frame with the concrete claim.",
+        "range": [
+          53440,
+          53495
+        ],
+        "ruleId": "generic-signposting",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 53497,
+        "line": 1219,
+        "loc": {
+          "end": {
+            "column": 57,
+            "line": 1219
+          },
+          "start": {
+            "column": 1,
+            "line": 1219
+          }
+        },
+        "message": "Generic signposting found: the-result-worth-attention. Replace the frame with the concrete claim.",
+        "range": [
+          53497,
+          53553
+        ],
+        "ruleId": "generic-signposting",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 53555,
+        "line": 1221,
+        "loc": {
+          "end": {
+            "column": 37,
+            "line": 1221
+          },
+          "start": {
+            "column": 1,
+            "line": 1221
+          }
+        },
+        "message": "Generic signposting found: the-real-problem-happens-downstream. Replace the frame with the concrete claim.",
+        "range": [
+          53555,
+          53591
+        ],
+        "ruleId": "generic-signposting",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 53593,
+        "line": 1223,
+        "loc": {
+          "end": {
+            "column": 31,
+            "line": 1223
+          },
+          "start": {
+            "column": 1,
+            "line": 1223
+          }
+        },
+        "message": "Generic signposting found: the-central-answer-lives-here. Replace the frame with the concrete claim.",
+        "range": [
+          53593,
+          53623
+        ],
+        "ruleId": "generic-signposting",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 53625,
+        "line": 1225,
+        "loc": {
+          "end": {
+            "column": 34,
+            "line": 1225
+          },
+          "start": {
+            "column": 1,
+            "line": 1225
+          }
+        },
+        "message": "Generic signposting found: the-useful-strategy-starts-there. Replace the frame with the concrete claim.",
+        "range": [
+          53625,
+          53658
+        ],
+        "ruleId": "generic-signposting",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 53660,
+        "line": 1227,
+        "loc": {
+          "end": {
+            "column": 65,
+            "line": 1227
+          },
+          "start": {
+            "column": 1,
+            "line": 1227
+          }
+        },
+        "message": "Negation reframe found: \"The CMO did not add another review. She set a release condition:\". Rewrite without the not-X-then-Y construction.",
+        "range": [
+          53660,
+          53724
+        ],
+        "ruleId": "negation-reframe",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 53726,
+        "line": 1229,
+        "loc": {
+          "end": {
+            "column": 63,
+            "line": 1229
+          },
+          "start": {
+            "column": 1,
+            "line": 1229
+          }
+        },
+        "message": "Negation reframe found: \"The CMO did not add another review. She set one launch policy:\". Rewrite without the not-X-then-Y construction.",
+        "range": [
+          53726,
+          53788
+        ],
+        "ruleId": "negation-reframe",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 53790,
+        "line": 1231,
+        "loc": {
+          "end": {
+            "column": 68,
+            "line": 1231
+          },
+          "start": {
+            "column": 1,
+            "line": 1231
+          }
+        },
+        "message": "Negation reframe found: \"The CMO did not add another review. She set a deployment principle:\". Rewrite without the not-X-then-Y construction.",
+        "range": [
+          53790,
+          53857
+        ],
+        "ruleId": "negation-reframe",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 53859,
+        "line": 1233,
+        "loc": {
+          "end": {
+            "column": 70,
+            "line": 1233
+          },
+          "start": {
+            "column": 1,
+            "line": 1233
+          }
+        },
+        "message": "Negation reframe found: \"The CMO did not add another review. She set one approval requirement:\". Rewrite without the not-X-then-Y construction.",
+        "range": [
+          53859,
+          53928
+        ],
+        "ruleId": "negation-reframe",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 53930,
+        "line": 1235,
+        "loc": {
+          "end": {
+            "column": 64,
+            "line": 1235
+          },
+          "start": {
+            "column": 1,
+            "line": 1235
+          }
+        },
+        "message": "Negation reframe found: \"The CMO did not add another review. She set a quality standard:\". Rewrite without the not-X-then-Y construction.",
+        "range": [
+          53930,
+          53993
+        ],
+        "ruleId": "negation-reframe",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 53995,
+        "line": 1237,
+        "loc": {
+          "end": {
+            "column": 67,
+            "line": 1237
+          },
+          "start": {
+            "column": 1,
+            "line": 1237
+          }
+        },
+        "message": "Negation reframe found: \"The CMO did not add another review. She set one release threshold:\". Rewrite without the not-X-then-Y construction.",
+        "range": [
+          53995,
+          54061
+        ],
+        "ruleId": "negation-reframe",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 54063,
+        "line": 1239,
+        "loc": {
+          "end": {
+            "column": 23,
+            "line": 1239
+          },
+          "start": {
+            "column": 1,
+            "line": 1239
+          }
+        },
+        "message": "Formula affirmation found: \"That's the good stuff!\". Replace the empty formula line with substance.",
+        "range": [
+          54063,
+          54085
+        ],
+        "ruleId": "affirmation-closers",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 54087,
+        "line": 1241,
+        "loc": {
+          "end": {
+            "column": 23,
+            "line": 1241
+          },
+          "start": {
+            "column": 1,
+            "line": 1241
+          }
+        },
+        "message": "Formula affirmation found: \"That is the good stuff\". Replace the empty formula line with substance.",
+        "range": [
+          54087,
+          54109
+        ],
+        "ruleId": "affirmation-closers",
+        "severity": 2,
+        "type": "lint"
       }
     ]
   },
@@ -13890,30 +14580,7 @@
             "line": 1
           }
         },
-        "message": "Coleman-Liau is 12.02. Keep it at 12 or lower.",
-        "range": [
-          0,
-          1
-        ],
-        "ruleId": "coleman-liau",
-        "severity": 2,
-        "type": "lint"
-      },
-      {
-        "column": 1,
-        "index": 0,
-        "line": 1,
-        "loc": {
-          "end": {
-            "column": 2,
-            "line": 1
-          },
-          "start": {
-            "column": 1,
-            "line": 1
-          }
-        },
-        "message": "Flesch Reading Ease is 40.25. Keep it at 61 or higher.",
+        "message": "Flesch Reading Ease is 45.02. Keep it at 61 or higher.",
         "range": [
           0,
           1
@@ -13936,7 +14603,7 @@
             "line": 1
           }
         },
-        "message": "Gunning Fog is 18.76. Keep it at 12 or lower.",
+        "message": "Gunning Fog is 16.62. Keep it at 12 or lower.",
         "range": [
           0,
           1

--- a/behavior/golden/textlint-rules-cases-syntactic-patterns/approved.normalized.json
+++ b/behavior/golden/textlint-rules-cases-syntactic-patterns/approved.normalized.json
@@ -16,7 +16,7 @@
             "line": 1
           }
         },
-        "message": "Flesch Reading Ease is 47.86. Keep it at 61 or higher.",
+        "message": "Flesch Reading Ease is 48.27. Keep it at 61 or higher.",
         "range": [
           0,
           1
@@ -39,7 +39,7 @@
             "line": 1
           }
         },
-        "message": "Gunning Fog is 15.07. Keep it at 12 or lower.",
+        "message": "Gunning Fog is 14.92. Keep it at 12 or lower.",
         "range": [
           0,
           1
@@ -13440,7 +13440,7 @@
         "line": 1161,
         "loc": {
           "end": {
-            "column": 46,
+            "column": 113,
             "line": 1161
           },
           "start": {
@@ -13448,10 +13448,10 @@
             "line": 1161
           }
         },
-        "message": "Negation reframe found: \"RAG doesn't replace search. It depends on it.\". Rewrite without the not-X-then-Y construction.",
+        "message": "Negation reframe found: \"AI isn't generating throwaway suggestions. It's producing production-ready code that changes how the team ships.\". Rewrite without the not-X-then-Y construction.",
         "range": [
           51625,
-          51670
+          51737
         ],
         "ruleId": "negation-reframe",
         "severity": 2,
@@ -13459,11 +13459,11 @@
       },
       {
         "column": 1,
-        "index": 51672,
+        "index": 51739,
         "line": 1163,
         "loc": {
           "end": {
-            "column": 33,
+            "column": 102,
             "line": 1163
           },
           "start": {
@@ -13471,10 +13471,10 @@
             "line": 1163
           }
         },
-        "message": "Negation reframe found: \"It is never sudden. It's timely.\". Rewrite without the not-X-then-Y construction.",
+        "message": "Negation reframe found: \"The audit trail is not a log. It's an immutable, queryable record of every decision the system makes.\". Rewrite without the not-X-then-Y construction.",
         "range": [
-          51672,
-          51704
+          51739,
+          51840
         ],
         "ruleId": "negation-reframe",
         "severity": 2,
@@ -13482,7 +13482,7 @@
       },
       {
         "column": 1,
-        "index": 51706,
+        "index": 51842,
         "line": 1165,
         "loc": {
           "end": {
@@ -13494,10 +13494,102 @@
             "line": 1165
           }
         },
-        "message": "Generic signposting found: it-was-important. Replace the frame with the concrete claim.",
+        "message": "Demonstrative emphasis found: \"This is not a framework.\". Reduce repeated short emphasis lines.",
         "range": [
-          51706,
-          51730
+          51842,
+          51866
+        ],
+        "ruleId": "demonstrative-emphasis",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 51842,
+        "line": 1165,
+        "loc": {
+          "end": {
+            "column": 98,
+            "line": 1165
+          },
+          "start": {
+            "column": 1,
+            "line": 1165
+          }
+        },
+        "message": "Negation reframe found: \"This is not a framework. It's a calibration layer that changes how every team evaluates the work.\". Rewrite without the not-X-then-Y construction.",
+        "range": [
+          51842,
+          51939
+        ],
+        "ruleId": "negation-reframe",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 51941,
+        "line": 1167,
+        "loc": {
+          "end": {
+            "column": 109,
+            "line": 1167
+          },
+          "start": {
+            "column": 1,
+            "line": 1167
+          }
+        },
+        "message": "Negation reframe found: \"The goal is not to stay motivated. The goal is to build a system that works even when motivation disappears.\". Rewrite without the not-X-then-Y construction.",
+        "range": [
+          51941,
+          52049
+        ],
+        "ruleId": "negation-reframe",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 51941,
+        "line": 1167,
+        "loc": {
+          "end": {
+            "column": 109,
+            "line": 1167
+          },
+          "start": {
+            "column": 1,
+            "line": 1167
+          }
+        },
+        "message": "Repeated sentence frame found: \"the goal is\". Vary the sentence frame.",
+        "range": [
+          51941,
+          52049
+        ],
+        "ruleId": "triple-repeat",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 36,
+        "index": 51976,
+        "line": 1167,
+        "loc": {
+          "end": {
+            "column": 109,
+            "line": 1167
+          },
+          "start": {
+            "column": 36,
+            "line": 1167
+          }
+        },
+        "message": "Generic signposting found: the-goal-is-to. Replace the frame with the concrete claim.",
+        "range": [
+          51976,
+          52049
         ],
         "ruleId": "generic-signposting",
         "severity": 2,
@@ -13505,22 +13597,206 @@
       },
       {
         "column": 1,
-        "index": 51706,
-        "line": 1165,
+        "index": 52051,
+        "line": 1169,
         "loc": {
           "end": {
-            "column": 41,
-            "line": 1165
+            "column": 96,
+            "line": 1169
           },
           "start": {
             "column": 1,
-            "line": 1165
+            "line": 1169
+          }
+        },
+        "message": "Negation reframe found: \"The fix is not more self-hate. It is better structure around the moments when avoidance starts.\". Rewrite without the not-X-then-Y construction.",
+        "range": [
+          52051,
+          52146
+        ],
+        "ruleId": "negation-reframe",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 52148,
+        "line": 1171,
+        "loc": {
+          "end": {
+            "column": 115,
+            "line": 1171
+          },
+          "start": {
+            "column": 1,
+            "line": 1171
+          }
+        },
+        "message": "Negation reframe found: \"Burnout is not a personal defect. It is often a mismatch between the demands of the job and the support around it.\". Rewrite without the not-X-then-Y construction.",
+        "range": [
+          52148,
+          52262
+        ],
+        "ruleId": "negation-reframe",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 52264,
+        "line": 1173,
+        "loc": {
+          "end": {
+            "column": 100,
+            "line": 1173
+          },
+          "start": {
+            "column": 1,
+            "line": 1173
+          }
+        },
+        "message": "Negation reframe found: \"Notifications are not neutral. They are tiny attention thieves that fragment every hour of the day.\". Rewrite without the not-X-then-Y construction.",
+        "range": [
+          52264,
+          52363
+        ],
+        "ruleId": "negation-reframe",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 52365,
+        "line": 1175,
+        "loc": {
+          "end": {
+            "column": 104,
+            "line": 1175
+          },
+          "start": {
+            "column": 1,
+            "line": 1175
+          }
+        },
+        "message": "Negation reframe found: \"Open Banking is not a regulation. It is a platform shift that changes who can build financial products.\". Rewrite without the not-X-then-Y construction.",
+        "range": [
+          52365,
+          52468
+        ],
+        "ruleId": "negation-reframe",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 52470,
+        "line": 1177,
+        "loc": {
+          "end": {
+            "column": 116,
+            "line": 1177
+          },
+          "start": {
+            "column": 1,
+            "line": 1177
+          }
+        },
+        "message": "Negation reframe found: \"Leadership is not a title on an organization chart. It is defined by courage, judgment, and service under pressure.\". Rewrite without the not-X-then-Y construction.",
+        "range": [
+          52470,
+          52585
+        ],
+        "ruleId": "negation-reframe",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 52587,
+        "line": 1179,
+        "loc": {
+          "end": {
+            "column": 46,
+            "line": 1179
+          },
+          "start": {
+            "column": 1,
+            "line": 1179
+          }
+        },
+        "message": "Negation reframe found: \"RAG doesn't replace search. It depends on it.\". Rewrite without the not-X-then-Y construction.",
+        "range": [
+          52587,
+          52632
+        ],
+        "ruleId": "negation-reframe",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 52634,
+        "line": 1181,
+        "loc": {
+          "end": {
+            "column": 33,
+            "line": 1181
+          },
+          "start": {
+            "column": 1,
+            "line": 1181
+          }
+        },
+        "message": "Negation reframe found: \"It is never sudden. It's timely.\". Rewrite without the not-X-then-Y construction.",
+        "range": [
+          52634,
+          52666
+        ],
+        "ruleId": "negation-reframe",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 52668,
+        "line": 1183,
+        "loc": {
+          "end": {
+            "column": 25,
+            "line": 1183
+          },
+          "start": {
+            "column": 1,
+            "line": 1183
+          }
+        },
+        "message": "Generic signposting found: it-was-important. Replace the frame with the concrete claim.",
+        "range": [
+          52668,
+          52692
+        ],
+        "ruleId": "generic-signposting",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 52668,
+        "line": 1183,
+        "loc": {
+          "end": {
+            "column": 41,
+            "line": 1183
+          },
+          "start": {
+            "column": 1,
+            "line": 1183
           }
         },
         "message": "Negation reframe found: \"It was nobody important. It was a guest.\". Rewrite without the not-X-then-Y construction.",
         "range": [
-          51706,
-          51746
+          52668,
+          52708
         ],
         "ruleId": "negation-reframe",
         "severity": 2,
@@ -13528,22 +13804,22 @@
       },
       {
         "column": 1,
-        "index": 51748,
-        "line": 1167,
+        "index": 52710,
+        "line": 1185,
         "loc": {
           "end": {
             "column": 50,
-            "line": 1167
+            "line": 1185
           },
           "start": {
             "column": 1,
-            "line": 1167
+            "line": 1185
           }
         },
         "message": "Negation reframe found: \"Automation does not solve ownership. It moves it.\". Rewrite without the not-X-then-Y construction.",
         "range": [
-          51748,
-          51797
+          52710,
+          52759
         ],
         "ruleId": "negation-reframe",
         "severity": 2,
@@ -13551,22 +13827,22 @@
       },
       {
         "column": 1,
-        "index": 51799,
-        "line": 1169,
+        "index": 52761,
+        "line": 1187,
         "loc": {
           "end": {
             "column": 48,
-            "line": 1169
+            "line": 1187
           },
           "start": {
             "column": 1,
-            "line": 1169
+            "line": 1187
           }
         },
         "message": "Negation reframe found: \"Search doesn't create authority. It exposes it.\". Rewrite without the not-X-then-Y construction.",
         "range": [
-          51799,
-          51846
+          52761,
+          52808
         ],
         "ruleId": "negation-reframe",
         "severity": 2,
@@ -13574,22 +13850,22 @@
       },
       {
         "column": 1,
-        "index": 51848,
-        "line": 1171,
+        "index": 52810,
+        "line": 1189,
         "loc": {
           "end": {
             "column": 45,
-            "line": 1171
+            "line": 1189
           },
           "start": {
             "column": 1,
-            "line": 1171
+            "line": 1189
           }
         },
         "message": "Negation reframe found: \"Growth is never the point. It's the residue.\". Rewrite without the not-X-then-Y construction.",
         "range": [
-          51848,
-          51892
+          52810,
+          52854
         ],
         "ruleId": "negation-reframe",
         "severity": 2,
@@ -13614,7 +13890,7 @@
             "line": 1
           }
         },
-        "message": "Coleman-Liau is 12.67. Keep it at 12 or lower.",
+        "message": "Coleman-Liau is 12.02. Keep it at 12 or lower.",
         "range": [
           0,
           1
@@ -13637,7 +13913,7 @@
             "line": 1
           }
         },
-        "message": "Flesch Reading Ease is 27.16. Keep it at 61 or higher.",
+        "message": "Flesch Reading Ease is 40.25. Keep it at 61 or higher.",
         "range": [
           0,
           1
@@ -13660,7 +13936,7 @@
             "line": 1
           }
         },
-        "message": "Gunning Fog is 23.48. Keep it at 12 or lower.",
+        "message": "Gunning Fog is 18.76. Keep it at 12 or lower.",
         "range": [
           0,
           1

--- a/behavior/golden/textlint-rules-cases-syntactic-patterns/approved.normalized.json
+++ b/behavior/golden/textlint-rules-cases-syntactic-patterns/approved.normalized.json
@@ -16,7 +16,7 @@
             "line": 1
           }
         },
-        "message": "Flesch Reading Ease is 47.25. Keep it at 61 or higher.",
+        "message": "Flesch Reading Ease is 47.86. Keep it at 61 or higher.",
         "range": [
           0,
           1
@@ -39,7 +39,7 @@
             "line": 1
           }
         },
-        "message": "Gunning Fog is 15.31. Keep it at 12 or lower.",
+        "message": "Gunning Fog is 15.07. Keep it at 12 or lower.",
         "range": [
           0,
           1
@@ -13410,6 +13410,190 @@
         "ruleId": "fragment-stacking",
         "severity": 2,
         "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 51523,
+        "line": 1159,
+        "loc": {
+          "end": {
+            "column": 101,
+            "line": 1159
+          },
+          "start": {
+            "column": 1,
+            "line": 1159
+          }
+        },
+        "message": "Negation reframe found: \"Indexing isn't the boring technical step anymore. It's the gate everything else has to pass through.\". Rewrite without the not-X-then-Y construction.",
+        "range": [
+          51523,
+          51623
+        ],
+        "ruleId": "negation-reframe",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 51625,
+        "line": 1161,
+        "loc": {
+          "end": {
+            "column": 46,
+            "line": 1161
+          },
+          "start": {
+            "column": 1,
+            "line": 1161
+          }
+        },
+        "message": "Negation reframe found: \"RAG doesn't replace search. It depends on it.\". Rewrite without the not-X-then-Y construction.",
+        "range": [
+          51625,
+          51670
+        ],
+        "ruleId": "negation-reframe",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 51672,
+        "line": 1163,
+        "loc": {
+          "end": {
+            "column": 33,
+            "line": 1163
+          },
+          "start": {
+            "column": 1,
+            "line": 1163
+          }
+        },
+        "message": "Negation reframe found: \"It is never sudden. It's timely.\". Rewrite without the not-X-then-Y construction.",
+        "range": [
+          51672,
+          51704
+        ],
+        "ruleId": "negation-reframe",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 51706,
+        "line": 1165,
+        "loc": {
+          "end": {
+            "column": 25,
+            "line": 1165
+          },
+          "start": {
+            "column": 1,
+            "line": 1165
+          }
+        },
+        "message": "Generic signposting found: it-was-important. Replace the frame with the concrete claim.",
+        "range": [
+          51706,
+          51730
+        ],
+        "ruleId": "generic-signposting",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 51706,
+        "line": 1165,
+        "loc": {
+          "end": {
+            "column": 41,
+            "line": 1165
+          },
+          "start": {
+            "column": 1,
+            "line": 1165
+          }
+        },
+        "message": "Negation reframe found: \"It was nobody important. It was a guest.\". Rewrite without the not-X-then-Y construction.",
+        "range": [
+          51706,
+          51746
+        ],
+        "ruleId": "negation-reframe",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 51748,
+        "line": 1167,
+        "loc": {
+          "end": {
+            "column": 50,
+            "line": 1167
+          },
+          "start": {
+            "column": 1,
+            "line": 1167
+          }
+        },
+        "message": "Negation reframe found: \"Automation does not solve ownership. It moves it.\". Rewrite without the not-X-then-Y construction.",
+        "range": [
+          51748,
+          51797
+        ],
+        "ruleId": "negation-reframe",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 51799,
+        "line": 1169,
+        "loc": {
+          "end": {
+            "column": 48,
+            "line": 1169
+          },
+          "start": {
+            "column": 1,
+            "line": 1169
+          }
+        },
+        "message": "Negation reframe found: \"Search doesn't create authority. It exposes it.\". Rewrite without the not-X-then-Y construction.",
+        "range": [
+          51799,
+          51846
+        ],
+        "ruleId": "negation-reframe",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 51848,
+        "line": 1171,
+        "loc": {
+          "end": {
+            "column": 45,
+            "line": 1171
+          },
+          "start": {
+            "column": 1,
+            "line": 1171
+          }
+        },
+        "message": "Negation reframe found: \"Growth is never the point. It's the residue.\". Rewrite without the not-X-then-Y construction.",
+        "range": [
+          51848,
+          51892
+        ],
+        "ruleId": "negation-reframe",
+        "severity": 2,
+        "type": "lint"
       }
     ]
   },
@@ -13453,7 +13637,7 @@
             "line": 1
           }
         },
-        "message": "Flesch Reading Ease is 25.33. Keep it at 61 or higher.",
+        "message": "Flesch Reading Ease is 27.16. Keep it at 61 or higher.",
         "range": [
           0,
           1
@@ -13476,7 +13660,7 @@
             "line": 1
           }
         },
-        "message": "Gunning Fog is 24.11. Keep it at 12 or lower.",
+        "message": "Gunning Fog is 23.48. Keep it at 12 or lower.",
         "range": [
           0,
           1

--- a/behavior/golden/textlint-rules-cases-syntactic-patterns/approved.normalized.json
+++ b/behavior/golden/textlint-rules-cases-syntactic-patterns/approved.normalized.json
@@ -14560,6 +14560,75 @@
         "ruleId": "affirmation-closers",
         "severity": 2,
         "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 54111,
+        "line": 1243,
+        "loc": {
+          "end": {
+            "column": 62,
+            "line": 1243
+          },
+          "start": {
+            "column": 1,
+            "line": 1243
+          }
+        },
+        "message": "Generic signposting found: is-load-bearing. Replace the frame with the concrete claim.",
+        "range": [
+          54111,
+          54172
+        ],
+        "ruleId": "generic-signposting",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 54174,
+        "line": 1245,
+        "loc": {
+          "end": {
+            "column": 56,
+            "line": 1245
+          },
+          "start": {
+            "column": 1,
+            "line": 1245
+          }
+        },
+        "message": "Generic signposting found: is-doing-real-work. Replace the frame with the concrete claim.",
+        "range": [
+          54174,
+          54229
+        ],
+        "ruleId": "generic-signposting",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 54231,
+        "line": 1247,
+        "loc": {
+          "end": {
+            "column": 75,
+            "line": 1247
+          },
+          "start": {
+            "column": 1,
+            "line": 1247
+          }
+        },
+        "message": "Negation reframe found: \"The editor does not request another draft. She sets an approval threshold:\". Rewrite without the not-X-then-Y construction.",
+        "range": [
+          54231,
+          54305
+        ],
+        "ruleId": "negation-reframe",
+        "severity": 2,
+        "type": "lint"
       }
     ]
   },
@@ -14580,7 +14649,7 @@
             "line": 1
           }
         },
-        "message": "Flesch Reading Ease is 45.02. Keep it at 61 or higher.",
+        "message": "Flesch Reading Ease is 44.92. Keep it at 61 or higher.",
         "range": [
           0,
           1
@@ -14603,7 +14672,7 @@
             "line": 1
           }
         },
-        "message": "Gunning Fog is 16.62. Keep it at 12 or lower.",
+        "message": "Gunning Fog is 16.67. Keep it at 12 or lower.",
         "range": [
           0,
           1

--- a/cspell.config.json
+++ b/cspell.config.json
@@ -3,6 +3,7 @@
   "language": "en",
   "words": [
     "actuallyactual",
+    "Allsup",
     "Archi",
     "autoplay",
     "Bardi",
@@ -14,6 +15,7 @@
     "codebook",
     "ation",
     "dysregulation",
+    "DTLS",
     "fdescribe",
     "flesch",
     "g3ts",
@@ -40,6 +42,7 @@
     "reimagining",
     "Remal",
     "rhythmed",
+    "RTCP",
     "SARIF",
     "scorekeeping",
     "seochecks",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "slopless",
-  "version": "0.2.23",
+  "version": "0.2.24",
   "description": "Deterministic textlint rules and CLI for catching prose slop in English Markdown.",
   "keywords": [
     "textlint",

--- a/src/rules/semantic-thinness/patterns/empty-quantification.json
+++ b/src/rules/semantic-thinness/patterns/empty-quantification.json
@@ -1,0 +1,33 @@
+{
+  "id": "empty-quantification",
+  "class": "empty-quantification",
+  "purpose": "Catch claims that minimize an unexplained act of quantification instead of naming the metric, measurement, or result.",
+  "matchMode": "contains",
+  "maxTokens": 24,
+  "templates": ["{minimizer} put a number on {deicticObject}."],
+  "slots": {
+    "minimizer": ["just", "simply", "merely", "basically"],
+    "deicticObject": ["it", "this", "that"]
+  },
+  "rejectIf": [
+    "sentence names the metric, measured value, scale, or numbered label",
+    "sentence explains how the number was calculated or where it came from",
+    "sentence uses put literally rather than as an empty quantification claim"
+  ],
+  "positiveExamples": [
+    "The report just put a number on it.",
+    "The dashboard simply put a number on this.",
+    "The analysis merely put a number on that.",
+    "The model basically put a number on it."
+  ],
+  "negativeExamples": [
+    "The analyst labeled the third bar 42.",
+    "The meter measured the pressure at 18 PSI.",
+    "The report calculated the score from twelve survey responses.",
+    "She put the numbered label on the archive box."
+  ],
+  "notes": [
+    "The template begins at the minimizer so contains mode permits arbitrary preceding subjects without enumerating them.",
+    "The common semantic-thinness matcher rejects concrete markers, measured values, and explanatory connectors before this pattern is evaluated."
+  ]
+}

--- a/src/rules/semantic-thinness/patterns/empty-quantification.json
+++ b/src/rules/semantic-thinness/patterns/empty-quantification.json
@@ -2,7 +2,7 @@
   "id": "empty-quantification",
   "class": "empty-quantification",
   "purpose": "Catch claims that minimize an unexplained act of quantification instead of naming the metric, measurement, or result.",
-  "matchMode": "contains",
+  "matchMode": "suffix",
   "maxTokens": 24,
   "templates": ["{minimizer} put a number on {deicticObject}."],
   "slots": {
@@ -27,7 +27,7 @@
     "She put the numbered label on the archive box."
   ],
   "notes": [
-    "The template begins at the minimizer so contains mode permits arbitrary preceding subjects without enumerating them.",
-    "The common semantic-thinness matcher rejects concrete markers, measured values, and explanatory connectors before this pattern is evaluated."
+    "The template begins at the minimizer so suffix mode permits arbitrary preceding subjects without enumerating them.",
+    "Suffix mode permits arbitrary preceding subjects but requires the vague quantification phrase to end the sentence, excluding measurements, explanations, and literal continuations."
   ]
 }

--- a/src/rules/semantic-thinness/private/pattern-data-e.ts
+++ b/src/rules/semantic-thinness/private/pattern-data-e.ts
@@ -1,6 +1,8 @@
+import emptyQuantification from "../patterns/empty-quantification.json" with { type: "json" };
 import recursiveMeaningFrame from "../patterns/recursive-meaning-frame.json" with { type: "json" };
 import type { SemanticThinnessPattern } from "./pattern-matcher.js";
 
 export const semanticThinnessPatternSetE: readonly SemanticThinnessPattern[] = [
+  emptyQuantification,
   recursiveMeaningFrame
 ];

--- a/src/rules/semantic-thinness/private/pattern-matcher.ts
+++ b/src/rules/semantic-thinness/private/pattern-matcher.ts
@@ -41,7 +41,7 @@ type CompiledTemplate = {
 type CompiledPattern = {
   readonly class: string;
   readonly id: string;
-  readonly matchMode: "contains" | "full";
+  readonly matchMode: "contains" | "full" | "suffix";
   readonly maxTokens: number;
   readonly purpose: string;
   readonly slotValues: Readonly<Record<string, readonly (readonly string[])[]>>;
@@ -150,8 +150,13 @@ export function compileSemanticThinnessPatterns(
 ): readonly CompiledPattern[] {
   const matchModeFor = (
     pattern: SemanticThinnessPattern
-  ): "contains" | "full" =>
-    pattern.matchMode === "contains" ? "contains" : "full";
+  ): "contains" | "full" | "suffix" => {
+    if (pattern.matchMode === "contains" || pattern.matchMode === "suffix") {
+      return pattern.matchMode;
+    }
+
+    return "full";
+  };
 
   const defaultMaxTokensFor = (pattern: SemanticThinnessPattern): number =>
     matchModeFor(pattern) === "contains"

--- a/src/rules/syntactic-patterns/closers/affirmation-closers.ts
+++ b/src/rules/syntactic-patterns/closers/affirmation-closers.ts
@@ -6,6 +6,10 @@ import {
 import { wordTokens } from "../../../shared/text/tokens.js";
 
 const CLOSERS = ["and that's the key.", "that's what matters."];
+const EXACT_FORMULA_LINES = new Set([
+  "that's the good stuff",
+  "that is the good stuff"
+]);
 const FORMULA_TAILS = [
   "key",
   "point",
@@ -18,11 +22,17 @@ const FORMULA_TAILS = [
 
 function isFormulaLine(text: string): boolean {
   const lower = text.toLocaleLowerCase("en");
+  let punctuationStart = lower.length;
+  while ([".", "!", "?"].includes(lower[punctuationStart - 1] ?? "")) {
+    punctuationStart -= 1;
+  }
+  const withoutTerminalPunctuation = lower.slice(0, punctuationStart);
 
   return (
-    wordTokens(text).length <= 6 &&
-    (lower.startsWith("that's the ") || lower.startsWith("that is the ")) &&
-    FORMULA_TAILS.some((tail) => lower.includes(tail))
+    EXACT_FORMULA_LINES.has(withoutTerminalPunctuation) ||
+    (wordTokens(text).length <= 6 &&
+      (lower.startsWith("that's the ") || lower.startsWith("that is the ")) &&
+      FORMULA_TAILS.some((tail) => lower.includes(tail)))
   );
 }
 

--- a/src/rules/syntactic-patterns/contrast/private/copular-reframe.ts
+++ b/src/rules/syntactic-patterns/contrast/private/copular-reframe.ts
@@ -1,0 +1,97 @@
+import {
+  NEGATION_WORDS,
+  PASSIVE_DEFINITION_VERBS,
+  findCopularNegation,
+  pronounCopulaStart,
+  skipOptionalAdverbs,
+  startsWithPronounCopula,
+  startsWithWords,
+  startsWithSubjectCopula,
+  validSubject,
+  words
+} from "./negation-reframe-parts.js";
+import type { Token } from "../../../../shared/text/tokens.js";
+
+export function sameSubjectCopularReframe(
+  aTokens: readonly Token[],
+  bTokens: readonly Token[]
+): boolean {
+  const negation = findCopularNegation(aTokens);
+
+  if (negation === undefined || !validSubject(negation.subject)) {
+    return false;
+  }
+
+  return startsWithSubjectCopula(
+    bTokens,
+    negation.subject,
+    negation.affirmativeAux
+  );
+}
+
+export function pronounCopularReframe(
+  aTokens: readonly Token[],
+  bTokens: readonly Token[]
+): boolean {
+  const negation = findCopularNegation(aTokens);
+
+  return (
+    negation !== undefined &&
+    validSubject(negation.subject) &&
+    !looksLikePassiveDefinition(bTokens) &&
+    !startsWithNegatedPronounCopula(bTokens) &&
+    startsWithPronounCopula(bTokens)
+  );
+}
+
+export function progressiveVerbMirror(
+  aTokens: readonly Token[],
+  bTokens: readonly Token[]
+): boolean {
+  const negation = findCopularNegation(aTokens);
+
+  if (negation === undefined || !validSubject(negation.subject)) {
+    return false;
+  }
+
+  const tokenWords = words(aTokens);
+  const predicateIndex = skipOptionalAdverbs(
+    tokenWords,
+    negation.negatedPredicateStart
+  );
+  const verb = tokenWords[predicateIndex];
+
+  return (
+    verb !== undefined &&
+    verb.endsWith("ing") &&
+    startsWithWords(bTokens, [
+      ...negation.subject,
+      negation.affirmativeAux,
+      verb
+    ])
+  );
+}
+
+export function startsWithNegatedPronounCopula(
+  tokens: readonly Token[]
+): boolean {
+  const start = pronounCopulaStart(tokens);
+  if (start === undefined) {
+    return false;
+  }
+
+  const tokenWords = words(tokens);
+  const predicateIndex = skipOptionalAdverbs(tokenWords, start.predicateStart);
+
+  return NEGATION_WORDS.has(tokenWords[predicateIndex] ?? "");
+}
+
+function looksLikePassiveDefinition(tokens: readonly Token[]): boolean {
+  const tokenWords = words(tokens);
+  const start = pronounCopulaStart(tokens);
+  if (start?.subject[0] !== "it") {
+    return false;
+  }
+
+  return PASSIVE_DEFINITION_VERBS.has(tokenWords[start.predicateStart] ?? "");
+}

--- a/src/rules/syntactic-patterns/contrast/private/copular-reframe.ts
+++ b/src/rules/syntactic-patterns/contrast/private/copular-reframe.ts
@@ -1,6 +1,5 @@
 import {
   NEGATION_WORDS,
-  PASSIVE_DEFINITION_VERBS,
   findCopularNegation,
   pronounCopulaStart,
   skipOptionalAdverbs,
@@ -38,7 +37,6 @@ export function pronounCopularReframe(
   return (
     negation !== undefined &&
     validSubject(negation.subject) &&
-    !looksLikePassiveDefinition(bTokens) &&
     !startsWithNegatedPronounCopula(bTokens) &&
     startsWithPronounCopula(bTokens)
   );
@@ -84,14 +82,4 @@ export function startsWithNegatedPronounCopula(
   const predicateIndex = skipOptionalAdverbs(tokenWords, start.predicateStart);
 
   return NEGATION_WORDS.has(tokenWords[predicateIndex] ?? "");
-}
-
-function looksLikePassiveDefinition(tokens: readonly Token[]): boolean {
-  const tokenWords = words(tokens);
-  const start = pronounCopulaStart(tokens);
-  if (start?.subject[0] !== "it") {
-    return false;
-  }
-
-  return PASSIVE_DEFINITION_VERBS.has(tokenWords[start.predicateStart] ?? "");
 }

--- a/src/rules/syntactic-patterns/contrast/private/negation-reframe-matcher.ts
+++ b/src/rules/syntactic-patterns/contrast/private/negation-reframe-matcher.ts
@@ -32,6 +32,7 @@ import {
   progressiveVerbMirror,
   pronounCopularReframe,
   sameSubjectCopularReframe,
+  shouldReportCopularReframe,
   startsWithNegatedPronounCopula
 } from "./negative-slop-frames.js";
 import { makeMeaningReframe, meaningReframe } from "./meaning-reframe.js";
@@ -235,6 +236,7 @@ function sentencePairReframe(
 ): NegationReframeMatch | undefined {
   const aTokens = wordTokens(a.text);
   const bTokens = wordTokens(b.text);
+  const pairText = `${a.text} ${b.text}`;
 
   if (
     !isCompleteSentence(a) ||
@@ -245,18 +247,21 @@ function sentencePairReframe(
   }
 
   if (
-    sameSubjectCopularReframe(aTokens, bTokens) ||
-    pronounCopularReframe(aTokens, bTokens) ||
-    progressiveVerbMirror(aTokens, bTokens) ||
+    (shouldReportCopularReframe(aTokens, bTokens, pairText) &&
+      (sameSubjectCopularReframe(aTokens, bTokens) ||
+        pronounCopularReframe(aTokens, bTokens) ||
+        progressiveVerbMirror(aTokens, bTokens))) ||
     (startsWithExplicitReplacement(bTokens) &&
-      !hasConcreteCorrectionEvidence(`${a.text} ${b.text}`)) ||
+      shouldReportCopularReframe(aTokens, bTokens, pairText) &&
+      !hasConcreteCorrectionEvidence(pairText)) ||
     meaningReframe(aTokens, bTokens) ||
     makeMeaningReframe(aTokens, bTokens) ||
     needReframe(aTokens, bTokens) ||
     actionVerbMirror(aTokens, bTokens) ||
     negatedActionPronounPayoff(aTokens, bTokens) ||
     negativeSlopReframe(aTokens, bTokens) ||
-    explicitContrastPivotReframe(aTokens, bTokens)
+    (shouldReportCopularReframe(aTokens, bTokens, pairText) &&
+      explicitContrastPivotReframe(aTokens, bTokens))
   ) {
     return {
       end: b.end,

--- a/src/rules/syntactic-patterns/contrast/private/negation-reframe-matcher.ts
+++ b/src/rules/syntactic-patterns/contrast/private/negation-reframe-matcher.ts
@@ -1,15 +1,11 @@
 import {
   DO_NEGATIONS,
   EXPLICIT_DO_AUXILIARIES,
-  NEGATION_WORDS,
-  PASSIVE_DEFINITION_VERBS,
-  PRONOUN_REFRAME_STARTS,
   contrastPivotSubject,
   findCopularNegation,
   findNegationIndex,
   isCompleteSentence,
   skipOptionalAdverbs,
-  startsWithAny,
   startsWithSubjectOrPronoun,
   startsWithSubjectVerb,
   startsWithWords,
@@ -31,7 +27,12 @@ import {
 } from "./inline-short-negation.js";
 import {
   hasNegativeSlopPairSignal,
-  negativeSlopReframe
+  negatedActionPronounPayoff,
+  negativeSlopReframe,
+  progressiveVerbMirror,
+  pronounCopularReframe,
+  sameSubjectCopularReframe,
+  startsWithNegatedPronounCopula
 } from "./negative-slop-frames.js";
 import { makeMeaningReframe, meaningReframe } from "./meaning-reframe.js";
 import { hasConcreteCorrectionEvidence } from "../../../../shared/matchers/concrete-evidence.js";
@@ -40,7 +41,6 @@ import {
   type SplitSentence
 } from "../../../../shared/text/sentences.js";
 import { wordTokens, type Token } from "../../../../shared/text/tokens.js";
-
 export type NegationReframeMatch = {
   readonly end: number;
   readonly start: number;
@@ -111,80 +111,6 @@ function inlineNegationContrast(
         text: sentence.text
       }
     : undefined;
-}
-
-function sameSubjectCopularReframe(
-  aTokens: readonly Token[],
-  bTokens: readonly Token[]
-): boolean {
-  const negation = findCopularNegation(aTokens);
-
-  if (negation === undefined || !validSubject(negation.subject)) {
-    return false;
-  }
-
-  return startsWithWords(bTokens, [
-    ...negation.subject,
-    negation.affirmativeAux
-  ]);
-}
-
-function pronounCopularReframe(
-  aTokens: readonly Token[],
-  bTokens: readonly Token[]
-): boolean {
-  const negation = findCopularNegation(aTokens);
-
-  return (
-    negation !== undefined &&
-    validSubject(negation.subject) &&
-    !looksLikePassiveDefinition(aTokens, bTokens) &&
-    !startsWithNegatedPronounCopula(bTokens) &&
-    startsWithAny(bTokens, PRONOUN_REFRAME_STARTS)
-  );
-}
-
-function startsWithNegatedPronounCopula(tokens: readonly Token[]): boolean {
-  for (const start of PRONOUN_REFRAME_STARTS) {
-    if (!startsWithWords(tokens, start)) {
-      continue;
-    }
-
-    const tokenWords = words(tokens);
-    const predicateIndex = skipOptionalAdverbs(tokenWords, start.length);
-
-    return NEGATION_WORDS.has(tokenWords[predicateIndex] ?? "");
-  }
-
-  return false;
-}
-
-function progressiveVerbMirror(
-  aTokens: readonly Token[],
-  bTokens: readonly Token[]
-): boolean {
-  const negation = findCopularNegation(aTokens);
-
-  if (negation === undefined || !validSubject(negation.subject)) {
-    return false;
-  }
-
-  const tokenWords = words(aTokens);
-  const predicateIndex = skipOptionalAdverbs(
-    tokenWords,
-    negation.negatedPredicateStart
-  );
-  const verb = tokenWords[predicateIndex];
-
-  return (
-    verb !== undefined &&
-    verb.endsWith("ing") &&
-    startsWithWords(bTokens, [
-      ...negation.subject,
-      negation.affirmativeAux,
-      verb
-    ])
-  );
 }
 
 function needReframe(
@@ -297,33 +223,10 @@ function startsWithExplicitReplacement(tokens: readonly Token[]): boolean {
 function hasPairNegationSignal(tokens: readonly Token[]): boolean {
   return (
     findNegationIndex(tokens) !== undefined ||
+    findCopularNegation(tokens) !== undefined ||
     contrastPivotSubject(tokens) !== undefined ||
     hasNegativeSlopPairSignal(tokens)
   );
-}
-
-function looksLikePassiveDefinition(
-  aTokens: readonly Token[],
-  bTokens: readonly Token[]
-): boolean {
-  const aWords = words(aTokens);
-  const bWords = words(bTokens);
-
-  for (let index = 0; index < aWords.length - 2; index += 1) {
-    const current = aWords[index];
-
-    if (
-      (current === "has" || current === "have" || current === "had") &&
-      aWords[index + 1] === "not" &&
-      aWords[index + 2] === "been" &&
-      startsWithWords(bTokens, ["it", "is"]) &&
-      PASSIVE_DEFINITION_VERBS.has(bWords[2] ?? "")
-    ) {
-      return true;
-    }
-  }
-
-  return false;
 }
 
 function sentencePairReframe(
@@ -351,6 +254,7 @@ function sentencePairReframe(
     makeMeaningReframe(aTokens, bTokens) ||
     needReframe(aTokens, bTokens) ||
     actionVerbMirror(aTokens, bTokens) ||
+    negatedActionPronounPayoff(aTokens, bTokens) ||
     negativeSlopReframe(aTokens, bTokens) ||
     explicitContrastPivotReframe(aTokens, bTokens)
   ) {

--- a/src/rules/syntactic-patterns/contrast/private/negation-reframe-matcher.ts
+++ b/src/rules/syntactic-patterns/contrast/private/negation-reframe-matcher.ts
@@ -28,6 +28,7 @@ import {
 import {
   hasNegativeSlopPairSignal,
   negatedActionPronounPayoff,
+  negatedActionSetReplacement,
   negativeSlopReframe,
   progressiveVerbMirror,
   pronounCopularReframe,
@@ -237,10 +238,16 @@ function sentencePairReframe(
   const aTokens = wordTokens(a.text);
   const bTokens = wordTokens(b.text);
   const pairText = `${a.text} ${b.text}`;
+  const hasNegatedActionSetReplacement = negatedActionSetReplacement(
+    aTokens,
+    bTokens
+  );
+  const hasAllowedReplacementColon =
+    b.text.trimEnd().endsWith(":") && hasNegatedActionSetReplacement;
 
   if (
     !isCompleteSentence(a) ||
-    !isCompleteSentence(b) ||
+    (!isCompleteSentence(b) && !hasAllowedReplacementColon) ||
     !hasPairNegationSignal(aTokens)
   ) {
     return undefined;

--- a/src/rules/syntactic-patterns/contrast/private/negation-reframe-parts.ts
+++ b/src/rules/syntactic-patterns/contrast/private/negation-reframe-parts.ts
@@ -3,6 +3,7 @@ import type { Token } from "../../../../shared/text/tokens.js";
 
 export const NEGATION_WORDS = new Set([
   "not",
+  "never",
   "isn't",
   "aren't",
   "wasn't",
@@ -63,16 +64,41 @@ export const PASSIVE_DEFINITION_VERBS = new Set([
   "classified",
   "defined",
   "described",
+  "entered",
   "linked",
   "marked",
-  "produced"
+  "produced",
+  "recorded"
 ]);
 const IRREGULAR_PAST_TENSE = new Map<string, string>([["go", "went"]]);
 const CONTRAST_PIVOT_AFTER_NOT = new Set(["just", "merely", "only"]);
+const NEGATIVE_COPULAR_PREDICATES = new Set([
+  "never",
+  "nobody",
+  "none",
+  "nothing",
+  "nowhere"
+]);
+const CONTRACTED_PRONOUN_COPULAS = new Map<
+  string,
+  { readonly affirmativeAux: string; readonly subject: readonly string[] }
+>([
+  ["it's", { affirmativeAux: "is", subject: ["it"] }],
+  ["that's", { affirmativeAux: "is", subject: ["that"] }],
+  ["they're", { affirmativeAux: "are", subject: ["they"] }],
+  ["we're", { affirmativeAux: "are", subject: ["we"] }],
+  ["you're", { affirmativeAux: "are", subject: ["you"] }]
+]);
 
 export type CopularNegation = {
   readonly affirmativeAux: string;
   readonly negatedPredicateStart: number;
+  readonly subject: readonly string[];
+};
+
+export type PronounCopulaStart = {
+  readonly affirmativeAux: string;
+  readonly predicateStart: number;
   readonly subject: readonly string[];
 };
 
@@ -177,6 +203,59 @@ export function startsWithAny(
   return starts.some((start) => startsWithWords(tokens, start));
 }
 
+export function pronounCopulaStart(
+  tokens: readonly Token[]
+): PronounCopulaStart | undefined {
+  const firstToken = tokens[0];
+  const contracted =
+    firstToken === undefined
+      ? undefined
+      : CONTRACTED_PRONOUN_COPULAS.get(firstToken.normalized);
+
+  if (contracted !== undefined) {
+    return { ...contracted, predicateStart: 1 };
+  }
+
+  for (const start of PRONOUN_REFRAME_STARTS) {
+    if (startsWithWords(tokens, start)) {
+      return {
+        affirmativeAux: start[1],
+        predicateStart: start.length,
+        subject: [start[0]]
+      };
+    }
+  }
+
+  return undefined;
+}
+
+export function startsWithPronounCopula(tokens: readonly Token[]): boolean {
+  return pronounCopulaStart(tokens) !== undefined;
+}
+
+export function startsWithSubjectCopula(
+  tokens: readonly Token[],
+  subject: readonly string[],
+  affirmativeAux: string
+): boolean {
+  if (startsWithWords(tokens, [...subject, affirmativeAux])) {
+    return true;
+  }
+
+  const contracted = CONTRACTED_PRONOUN_COPULAS.get(
+    tokens[0]?.normalized ?? ""
+  );
+
+  if (contracted?.affirmativeAux !== affirmativeAux) {
+    return false;
+  }
+
+  return (
+    subject.length === contracted.subject.length &&
+    subject.every((word, index) => word === contracted.subject[index])
+  );
+}
+
 export function isCompleteSentence(sentence: SplitSentence): boolean {
   const trimmed = sentence.text.trim();
   const last = trimmed.at(-1);
@@ -231,6 +310,30 @@ export function findCopularNegation(
       return {
         affirmativeAux: explicitAux,
         negatedPredicateStart: index + 2,
+        subject: tokenWords.slice(0, index)
+      };
+    }
+
+    if (
+      explicitAux !== undefined &&
+      next !== undefined &&
+      NEGATIVE_COPULAR_PREDICATES.has(next)
+    ) {
+      return {
+        affirmativeAux: explicitAux,
+        negatedPredicateStart: index + 1,
+        subject: tokenWords.slice(0, index)
+      };
+    }
+
+    if (
+      explicitAux !== undefined &&
+      next === "no" &&
+      (tokenWords[index + 2] === "one" || tokenWords[index + 2] === "single")
+    ) {
+      return {
+        affirmativeAux: explicitAux,
+        negatedPredicateStart: index + 1,
         subject: tokenWords.slice(0, index)
       };
     }

--- a/src/rules/syntactic-patterns/contrast/private/negation-reframe-parts.ts
+++ b/src/rules/syntactic-patterns/contrast/private/negation-reframe-parts.ts
@@ -58,18 +58,6 @@ export const PRONOUN_REFRAME_STARTS = [
   ["you", "are"],
   ["we", "are"]
 ] as const;
-export const PASSIVE_DEFINITION_VERBS = new Set([
-  "associated",
-  "caused",
-  "classified",
-  "defined",
-  "described",
-  "entered",
-  "linked",
-  "marked",
-  "produced",
-  "recorded"
-]);
 const IRREGULAR_PAST_TENSE = new Map<string, string>([["go", "went"]]);
 const CONTRAST_PIVOT_AFTER_NOT = new Set(["just", "merely", "only"]);
 const NEGATIVE_COPULAR_PREDICATES = new Set([

--- a/src/rules/syntactic-patterns/contrast/private/negative-slop-frames.ts
+++ b/src/rules/syntactic-patterns/contrast/private/negative-slop-frames.ts
@@ -1,4 +1,11 @@
 import type { Token } from "../../../../shared/text/tokens.js";
+import { hasFactualConnectorAfterNegation } from "./negation-context-gates.js";
+export {
+  progressiveVerbMirror,
+  pronounCopularReframe,
+  sameSubjectCopularReframe,
+  startsWithNegatedPronounCopula
+} from "./copular-reframe.js";
 import {
   DO_NEGATIONS,
   EXPLICIT_DO_AUXILIARIES,
@@ -42,6 +49,39 @@ const GENERIC_ACTION_VERBS = new Set([
   "walked",
   "went"
 ]);
+const NEGATED_ACTION_REFRAME_VERBS = new Set([
+  "avoid",
+  "change",
+  "create",
+  "end",
+  "erase",
+  "fix",
+  "guarantee",
+  "make",
+  "mean",
+  "remove",
+  "replace",
+  "require",
+  "skip",
+  "solve"
+]);
+const PRONOUN_PAYOFF_VERBS = new Set([
+  "becomes",
+  "creates",
+  "depends",
+  "exposes",
+  "lands",
+  "means",
+  "moves",
+  "needs",
+  "points",
+  "requires",
+  "reveals",
+  "shifts",
+  "shows",
+  "turns"
+]);
+const PRONOUN_SUBJECTS = new Set(["it", "this", "that", "they", "we", "you"]);
 
 function startsWithPassiveCopula(tokens: readonly Token[]): boolean {
   const tokenWords = words(tokens);
@@ -210,6 +250,60 @@ export function hasNegativeSlopPairSignal(tokens: readonly Token[]): boolean {
     hasTrailingProblemFrame(tokenWords) ||
     hasLeadingProblemFrame(tokenWords)
   );
+}
+
+export function negatedActionPronounPayoff(
+  aTokens: readonly Token[],
+  bTokens: readonly Token[]
+): boolean {
+  const aWords = words(aTokens);
+  const bWords = words(stripLeadingPairPivot(bTokens));
+  const pronounStart = PRONOUN_SUBJECTS.has(bWords[0] ?? "") ? 1 : undefined;
+  if (pronounStart === undefined) {
+    return false;
+  }
+
+  const payoffVerbIndex = skipOptionalAdverbs(bWords, pronounStart);
+  if (!PRONOUN_PAYOFF_VERBS.has(bWords[payoffVerbIndex] ?? "")) {
+    return false;
+  }
+
+  for (let index = 0; index < aWords.length; index += 1) {
+    if (hasNegatedReframeVerb(aTokens, aWords, index)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function hasNegatedReframeVerb(
+  tokens: readonly Token[],
+  tokenWords: readonly string[],
+  index: number
+): boolean {
+  const current = tokenWords[index];
+  const next = tokenWords[index + 1];
+  const subject = tokenWords.slice(0, index);
+
+  if (!validSubject(subject)) {
+    return false;
+  }
+
+  const negationIndex = DO_NEGATIONS.has(current ?? "")
+    ? index
+    : EXPLICIT_DO_AUXILIARIES.has(current ?? "") && next === "not"
+      ? index + 1
+      : undefined;
+  if (
+    negationIndex === undefined ||
+    hasFactualConnectorAfterNegation(tokens, negationIndex)
+  ) {
+    return false;
+  }
+
+  const verbIndex = skipOptionalAdverbs(tokenWords, negationIndex + 1);
+  return NEGATED_ACTION_REFRAME_VERBS.has(tokenWords[verbIndex] ?? "");
 }
 
 export function negativeSlopReframe(

--- a/src/rules/syntactic-patterns/contrast/private/negative-slop-frames.ts
+++ b/src/rules/syntactic-patterns/contrast/private/negative-slop-frames.ts
@@ -1,5 +1,6 @@
 import type { Token } from "../../../../shared/text/tokens.js";
 import { hasFactualConnectorAfterNegation } from "./negation-context-gates.js";
+export { shouldReportCopularReframe } from "./reframe-classification.js";
 export {
   progressiveVerbMirror,
   pronounCopularReframe,

--- a/src/rules/syntactic-patterns/contrast/private/negative-slop-frames.ts
+++ b/src/rules/syntactic-patterns/contrast/private/negative-slop-frames.ts
@@ -1,5 +1,6 @@
 import type { Token } from "../../../../shared/text/tokens.js";
 import { hasFactualConnectorAfterNegation } from "./negation-context-gates.js";
+import { hasAbstractPolicyDirectObject } from "./policy-object.js";
 export { shouldReportCopularReframe } from "./reframe-classification.js";
 export {
   progressiveVerbMirror,
@@ -66,6 +67,7 @@ const NEGATED_ACTION_REFRAME_VERBS = new Set([
   "skip",
   "solve"
 ]);
+const REPLACEMENT_SUBJECT_PRONOUNS = new Set(["he", "she"]);
 const PRONOUN_PAYOFF_VERBS = new Set([
   "becomes",
   "creates",
@@ -170,7 +172,25 @@ function negatedActionSubject(
   return undefined;
 }
 
-function negativeActionReplacement(
+function constrainedSetSubjectLength(
+  tokens: readonly Token[],
+  subject: readonly string[]
+): number | undefined {
+  if (startsWithWords(tokens, subject)) {
+    return subject.length;
+  }
+
+  if (startsWithSubjectOrPronoun(tokens, subject)) {
+    return 1;
+  }
+
+  return subject.length > 1 &&
+    REPLACEMENT_SUBJECT_PRONOUNS.has(tokens[0]?.normalized ?? "")
+    ? 1
+    : undefined;
+}
+
+export function negatedActionReplacement(
   aTokens: readonly Token[],
   bTokens: readonly Token[]
 ): boolean {
@@ -182,15 +202,40 @@ function negativeActionReplacement(
 
   const bContentTokens = stripLeadingPairPivot(bTokens);
   const bWords = words(bContentTokens);
-  const verbIndex = skipOptionalAdverbs(bWords, subject.length);
-  const verb = bWords[verbIndex];
+  const genericVerbIndex = skipOptionalAdverbs(bWords, subject.length);
 
   return (
     tokenWords.length <= 14 &&
     !hasAnyWord(tokenWords, FACTUAL_NEGATION_CONNECTORS) &&
-    startsWithSubjectOrPronoun(bContentTokens, subject) &&
-    verb !== undefined &&
-    GENERIC_ACTION_VERBS.has(verb)
+    ((startsWithSubjectOrPronoun(bContentTokens, subject) &&
+      GENERIC_ACTION_VERBS.has(bWords[genericVerbIndex] ?? "")) ||
+      negatedActionSetReplacement(aTokens, bTokens))
+  );
+}
+
+export function negatedActionSetReplacement(
+  aTokens: readonly Token[],
+  bTokens: readonly Token[]
+): boolean {
+  const tokenWords = words(aTokens);
+  const subject = negatedActionSubject(aTokens);
+  if (subject === undefined) {
+    return false;
+  }
+
+  const bContentTokens = stripLeadingPairPivot(bTokens);
+  const bWords = words(bContentTokens);
+  const subjectLength = constrainedSetSubjectLength(bContentTokens, subject);
+  const verbIndex =
+    subjectLength === undefined
+      ? undefined
+      : skipOptionalAdverbs(bWords, subjectLength);
+
+  return (
+    tokenWords.length <= 14 &&
+    !hasAnyWord(tokenWords, FACTUAL_NEGATION_CONNECTORS) &&
+    verbIndex !== undefined &&
+    hasAbstractPolicyDirectObject(bWords, verbIndex)
   );
 }
 
@@ -314,7 +359,7 @@ export function negativeSlopReframe(
   return (
     noLongerCopularReframe(aTokens, bTokens) ||
     fragmentDefinitionReframe(aTokens, bTokens) ||
-    negativeActionReplacement(aTokens, bTokens) ||
+    negatedActionReplacement(aTokens, bTokens) ||
     notBecauseReframe(aTokens, bTokens) ||
     notProblemReframe(aTokens, bTokens)
   );

--- a/src/rules/syntactic-patterns/contrast/private/policy-object.ts
+++ b/src/rules/syntactic-patterns/contrast/private/policy-object.ts
@@ -43,7 +43,7 @@ export function hasAbstractPolicyDirectObject(
   tokenWords: readonly string[],
   verbIndex: number
 ): boolean {
-  if (tokenWords[verbIndex] !== "set") {
+  if (!["set", "sets"].includes(tokenWords[verbIndex] ?? "")) {
     return false;
   }
 

--- a/src/rules/syntactic-patterns/contrast/private/policy-object.ts
+++ b/src/rules/syntactic-patterns/contrast/private/policy-object.ts
@@ -1,0 +1,62 @@
+const ABSTRACT_POLICY_OBJECTS = new Set([
+  "condition",
+  "criterion",
+  "policy",
+  "principle",
+  "requirement",
+  "rule",
+  "standard",
+  "threshold"
+]);
+const DIRECT_OBJECT_DETERMINERS = new Set([
+  "a",
+  "an",
+  "one",
+  "that",
+  "the",
+  "this"
+]);
+const POLICY_OBJECT_MODIFIERS = new Set([
+  "access",
+  "approval",
+  "business",
+  "content",
+  "deployment",
+  "editorial",
+  "governance",
+  "launch",
+  "operating",
+  "pricing",
+  "quality",
+  "release",
+  "review",
+  "safety",
+  "security",
+  "service",
+  "spending",
+  "technical",
+  "testing",
+  "usage"
+]);
+
+export function hasAbstractPolicyDirectObject(
+  tokenWords: readonly string[],
+  verbIndex: number
+): boolean {
+  if (tokenWords[verbIndex] !== "set") {
+    return false;
+  }
+
+  const objectTokens = tokenWords.slice(verbIndex + 1);
+  const directObject = DIRECT_OBJECT_DETERMINERS.has(objectTokens[0] ?? "")
+    ? objectTokens.slice(1)
+    : objectTokens;
+  const [first, second] = directObject;
+
+  return (
+    (directObject.length === 1 && ABSTRACT_POLICY_OBJECTS.has(first ?? "")) ||
+    (directObject.length === 2 &&
+      POLICY_OBJECT_MODIFIERS.has(first ?? "") &&
+      ABSTRACT_POLICY_OBJECTS.has(second ?? ""))
+  );
+}

--- a/src/rules/syntactic-patterns/contrast/private/reframe-classification.ts
+++ b/src/rules/syntactic-patterns/contrast/private/reframe-classification.ts
@@ -1,0 +1,288 @@
+import type { Token } from "../../../../shared/text/tokens.js";
+import {
+  FACTUAL_NEGATION_CONNECTORS,
+  findCopularNegation,
+  pronounCopulaStart,
+  stripLeadingPairPivot,
+  words
+} from "./negation-reframe-parts.js";
+
+const FRAMING_SUBJECT_NOUNS = new Set([
+  "answer",
+  "fix",
+  "goal",
+  "issue",
+  "key",
+  "point",
+  "problem",
+  "solution",
+  "strategy"
+]);
+const INSTRUCTION_ADJECTIVES = new Set([
+  "best",
+  "better",
+  "critical",
+  "essential",
+  "important",
+  "necessary",
+  "recommended",
+  "safest"
+]);
+const CONCRETE_PASSIVE_VERBS = new Set([
+  "associated",
+  "caused",
+  "classified",
+  "created",
+  "entered",
+  "linked",
+  "owned",
+  "paid",
+  "passed",
+  "produced",
+  "recorded",
+  "regulated",
+  "sent",
+  "stored",
+  "used"
+]);
+const REFERENCE_PASSIVE_VERBS = new Set(["defined", "described", "marked"]);
+const PASSIVE_EXPLANATION_LINKS = new Set([
+  "as",
+  "by",
+  "for",
+  "from",
+  "in",
+  "to",
+  "with"
+]);
+const CLAUSE_BOUNDARIES = new Set([
+  "and",
+  "but",
+  "that",
+  "when",
+  "where",
+  "which",
+  "while"
+]);
+const CONCRETE_RELATIONS = [
+  ["amount", "of"],
+  ["defined", "to", "be"],
+  ["derived", "from"],
+  ["intended", "for"],
+  ["owned", "by"],
+  ["property", "of"],
+  ["symptom", "of"],
+  ["unit", "of"]
+] as const;
+const MAX_SHORT_SENTENCE_WORDS = 6;
+const QUANTITY_WORDS = new Set([
+  "half",
+  "one",
+  "two",
+  "three",
+  "four",
+  "five",
+  "six",
+  "seven",
+  "eight",
+  "nine",
+  "ten"
+]);
+
+function digitTokenCount(tokens: readonly Token[]): number {
+  return tokens.filter((token) =>
+    [...token.text].some((character) => character >= "0" && character <= "9")
+  ).length;
+}
+
+function quantityTokenCount(tokens: readonly Token[]): number {
+  return (
+    digitTokenCount(tokens) +
+    tokens.filter((token) => QUANTITY_WORDS.has(token.normalized)).length
+  );
+}
+
+function acronymCount(tokens: readonly Token[]): number {
+  return tokens.filter(
+    (token) =>
+      token.text.length >= 2 &&
+      token.text === token.text.toLocaleUpperCase("en") &&
+      token.text !== token.text.toLocaleLowerCase("en")
+  ).length;
+}
+
+function properNameCount(tokens: readonly Token[]): number {
+  return tokens.filter((token, index) => {
+    const first = token.text[0];
+    return (
+      index > 0 &&
+      first !== undefined &&
+      first >= "A" &&
+      first <= "Z" &&
+      token.text !== token.text.toLocaleUpperCase("en")
+    );
+  }).length;
+}
+
+function hasReferenceEvidence(
+  aTokens: readonly Token[],
+  bTokens: readonly Token[],
+  pairText: string
+): boolean {
+  const digits = digitTokenCount(aTokens) + digitTokenCount(bTokens);
+  const quantities = quantityTokenCount(aTokens) + quantityTokenCount(bTokens);
+  const names = properNameCount(aTokens) + properNameCount(bTokens);
+  return (
+    digits >= 2 ||
+    pairText.includes("/") ||
+    pairText.includes("_") ||
+    pairText.includes("@") ||
+    (acronymCount(aTokens) + acronymCount(bTokens) >= 1 && digits >= 1) ||
+    names >= 3 ||
+    (names >= 2 && quantities >= 1)
+  );
+}
+
+function startsWithSequence(
+  source: readonly string[],
+  sequence: readonly string[]
+): boolean {
+  return sequence.every((word, index) => source[index] === word);
+}
+
+function containsSequence(
+  source: readonly string[],
+  sequence: readonly string[]
+): boolean {
+  for (let index = 0; index <= source.length - sequence.length; index += 1) {
+    if (startsWithSequence(source.slice(index), sequence)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function hasConcreteRelation(tokenWords: readonly string[]): boolean {
+  return CONCRETE_RELATIONS.some((relation) =>
+    containsSequence(tokenWords, relation)
+  );
+}
+
+function hasInstruction(tokens: readonly Token[]): boolean {
+  const tokenWords = words(tokens);
+  const start = pronounCopulaStart(tokens);
+  return (
+    start !== undefined &&
+    INSTRUCTION_ADJECTIVES.has(tokenWords[start.predicateStart] ?? "") &&
+    tokenWords[start.predicateStart + 1] === "to"
+  );
+}
+
+function hasPassiveExplanation(bTokens: readonly Token[]): boolean {
+  const tokenWords = words(bTokens);
+  const start = pronounCopulaStart(bTokens);
+  const isConcretePassive = (word: string): boolean =>
+    CONCRETE_PASSIVE_VERBS.has(word) || REFERENCE_PASSIVE_VERBS.has(word);
+
+  if (
+    start !== undefined &&
+    isConcretePassive(tokenWords[start.predicateStart] ?? "")
+  ) {
+    return true;
+  }
+
+  const boundary = tokenWords.findIndex((word) => CLAUSE_BOUNDARIES.has(word));
+  const firstClause = boundary < 0 ? tokenWords : tokenWords.slice(0, boundary);
+  return firstClause.some(
+    (word, index) =>
+      isConcretePassive(word) &&
+      PASSIVE_EXPLANATION_LINKS.has(firstClause[index + 1] ?? "")
+  );
+}
+
+function hasPurposeOrProvenance(tokenWords: readonly string[]): boolean {
+  return (
+    containsSequence(tokenWords, ["used", "to"]) ||
+    (["uses", "used"].includes(tokenWords[1] ?? "") &&
+      tokenWords.some(
+        (word, index) =>
+          ["created", "produced"].includes(word) &&
+          ["by", "from", "in"].includes(tokenWords[index + 1] ?? "")
+      ))
+  );
+}
+
+function hasCausalPassiveExplanation(
+  aTokens: readonly Token[],
+  bTokens: readonly Token[]
+): boolean {
+  return (
+    words(aTokens).some((word) => FACTUAL_NEGATION_CONNECTORS.has(word)) &&
+    hasPassiveExplanation(bTokens)
+  );
+}
+
+function hasDistinctCauseExplanation(
+  aTokens: readonly Token[],
+  bTokens: readonly Token[]
+): boolean {
+  const aWords = words(aTokens);
+  const bWords = words(stripLeadingPairPivot(bTokens));
+  return (
+    !aWords.includes("caused") && containsSequence(bWords, ["caused", "by"])
+  );
+}
+
+function hasConcreteExplanatoryEvidence(
+  aTokens: readonly Token[],
+  bTokens: readonly Token[],
+  pairText: string
+): boolean {
+  const tokenWords = words(stripLeadingPairPivot(bTokens));
+  return (
+    hasInstruction(bTokens) ||
+    hasConcreteRelation(tokenWords) ||
+    hasPurposeOrProvenance(tokenWords) ||
+    hasDistinctCauseExplanation(aTokens, bTokens) ||
+    hasCausalPassiveExplanation(aTokens, bTokens) ||
+    (hasReferenceEvidence(aTokens, bTokens, pairText) &&
+      hasPassiveExplanation(bTokens))
+  );
+}
+
+function hasFramingNoun(tokens: readonly Token[]): boolean {
+  const negation = findCopularNegation(tokens);
+  if (negation === undefined) {
+    return false;
+  }
+
+  const predicate = words(tokens).slice(
+    negation.negatedPredicateStart,
+    negation.negatedPredicateStart + 4
+  );
+  return [...negation.subject, ...predicate].some((word) =>
+    FRAMING_SUBJECT_NOUNS.has(word)
+  );
+}
+
+function isShortReversal(
+  aTokens: readonly Token[],
+  bTokens: readonly Token[]
+): boolean {
+  return (
+    aTokens.length <= MAX_SHORT_SENTENCE_WORDS &&
+    bTokens.length <= MAX_SHORT_SENTENCE_WORDS
+  );
+}
+
+export function shouldReportCopularReframe(
+  aTokens: readonly Token[],
+  bTokens: readonly Token[],
+  pairText: string
+): boolean {
+  return (
+    isShortReversal(aTokens, bTokens) ||
+    hasFramingNoun(aTokens) ||
+    !hasConcreteExplanatoryEvidence(aTokens, bTokens, pairText)
+  );
+}

--- a/src/rules/syntactic-patterns/lead-ins/generic-signposting.ts
+++ b/src/rules/syntactic-patterns/lead-ins/generic-signposting.ts
@@ -6,7 +6,11 @@ import {
   type SentenceMatch
 } from "../../../shared/matchers/prose-patterns.js";
 import { oneToOneRule } from "../../private/textlint-rule-builders.js";
-import { matchDiscourseEvaluationFrame } from "./private/discourse-evaluation.js";
+import {
+  isAbstractAuditFrame,
+  matchDiscourseEvaluationFrame,
+  matchExpandedDiscourseFrame
+} from "./private/discourse-evaluation.js";
 
 const PREFIXES = ["however, ", "but ", "and ", "so "];
 // "as such" was removed: it is a normal anaphoric connective ("a registered adviser; as
@@ -53,7 +57,6 @@ const FRAME_PATTERNS = [
   "the useful version is",
   "the point is plain enough"
 ];
-const DETERMINERS = ["a", "an", "the", "this", "that"];
 const SEQUENCE_PATTERNS = [
   "a simple sequence works well",
   "a simple pattern works well",
@@ -94,78 +97,12 @@ const WHAT_FRAME_TAIL_STARTERS = [
   "true",
   "usually"
 ];
-const FRAME_ADJECTIVES = [
-  "basic",
-  "best",
-  "better",
-  "biggest",
-  "bigger",
-  "central",
-  "clearest",
-  "core",
-  "easiest",
-  "final",
-  "first",
-  "hardest",
-  "honest",
-  "important",
-  "main",
-  "only",
-  "obvious",
-  "practical",
-  "real",
-  "simple",
-  "useful"
-];
-const FRAME_NOUNS = [
-  "answer",
-  "approach",
-  "challenge",
-  "choice",
-  "conclusion",
-  "fact",
-  "fix",
-  "focus",
-  "frame",
-  "idea",
-  "lesson",
-  "move",
-  "path",
-  "point",
-  "principle",
-  "priority",
-  "problem",
-  "question",
-  "result",
-  "rule",
-  "shift",
-  "signal",
-  "strategy",
-  "test",
-  "thing",
-  "tradeoff",
-  "truth",
-  "version",
-  "way",
-  "win"
-];
-const ABSTRACT_FRAME_VERBS = ["is", "are", "was"];
 const POINT_NOUNS = ["goal", "job", "key", "point", "takeaway", "trick"];
 
 function matchModifiedAbstractFrame(
   words: readonly string[]
 ): string | undefined {
-  const [first, second, third, fourth, fifth] = words;
-
-  if (
-    first === "the" &&
-    second === "result" &&
-    third === "worth" &&
-    fourth === "caring" &&
-    fifth === "about"
-  ) {
-    return "the-result-worth-caring-about";
-  }
+  const [first, second, third, fourth] = words;
 
   if (first !== "the") {
     return undefined;
@@ -181,25 +118,6 @@ function matchModifiedAbstractFrame(
   ]);
 
   return matches.get(key);
-}
-
-function matchEvaluativeFrame(words: readonly string[]): string | undefined {
-  const [first, second, third, fourth] = words;
-
-  if (
-    first !== undefined &&
-    second !== undefined &&
-    third !== undefined &&
-    fourth !== undefined &&
-    DETERMINERS.includes(first) &&
-    FRAME_ADJECTIVES.includes(second) &&
-    FRAME_NOUNS.includes(third) &&
-    ABSTRACT_FRAME_VERBS.includes(fourth)
-  ) {
-    return `the-${second}-${third}-${fourth}`;
-  }
-
-  return undefined;
 }
 
 function matchPointIsToFrame(words: readonly string[]): string | undefined {
@@ -253,8 +171,8 @@ function matchWhatFrame(words: readonly string[]): string | undefined {
 function matchAbstractFrame(text: string): string | undefined {
   const words = tokens(text);
   return (
+    matchExpandedDiscourseFrame(words) ??
     matchModifiedAbstractFrame(words) ??
-    matchEvaluativeFrame(words) ??
     matchDiscourseEvaluationFrame(words) ??
     matchPointIsToFrame(words) ??
     matchWhatFrame(words)
@@ -322,8 +240,16 @@ function matchGeneratedFormula(text: string): string | undefined {
 
 function matchSignposting(sentence: string): SentenceMatch | undefined {
   const stripped = cleanSentence(sentence, PREFIXES);
-  const concreteImplementation = hasConcreteImplementationSummary(stripped);
   const abstract = matchAbstractFrame(stripped);
+  const strippedWords = tokens(stripped);
+  const auditStart = isAbstractAuditFrame(strippedWords)
+    ? stripped.indexOf("audit")
+    : -1;
+  const concreteImplementation = hasConcreteImplementationSummary(
+    abstract !== undefined && auditStart >= 0
+      ? stripped.slice(0, auditStart) + stripped.slice(auditStart + 5)
+      : stripped
+  );
   const formulaicSetup = matchFormulaicContentSetup(stripped);
   const generatedFormula = matchGeneratedFormula(stripped);
 
@@ -335,6 +261,9 @@ function matchSignposting(sentence: string): SentenceMatch | undefined {
   }
   if (formulaicSetup !== undefined) {
     return { kind: "formulaic-content-setup", signal: formulaicSetup };
+  }
+  if (stripped.startsWith("the fun part is:") && !concreteImplementation) {
+    return { kind: "frame-signpost", signal: "the fun part is:" };
   }
 
   const checks: readonly (readonly [string, readonly string[]])[] = [

--- a/src/rules/syntactic-patterns/lead-ins/private/discourse-evaluation.ts
+++ b/src/rules/syntactic-patterns/lead-ins/private/discourse-evaluation.ts
@@ -1,4 +1,74 @@
 const ABSTRACT_FRAME_VERBS = ["is", "are", "was", "were"];
+const DISCOURSE_WORK_TAILS = [
+  ["doing", "real", "work"],
+  ["load", "bearing"]
+] as const;
+const DETERMINERS = new Set(["a", "an", "the", "this", "that"]);
+const FRAME_ADJECTIVES = new Set([
+  "basic",
+  "best",
+  "better",
+  "biggest",
+  "bigger",
+  "central",
+  "clearest",
+  "core",
+  "easiest",
+  "final",
+  "first",
+  "hardest",
+  "honest",
+  "important",
+  "main",
+  "only",
+  "obvious",
+  "practical",
+  "real",
+  "simple",
+  "useful"
+]);
+const FRAME_NOUNS = new Set([
+  "answer",
+  "approach",
+  "audit",
+  "challenge",
+  "choice",
+  "conclusion",
+  "diagnosis",
+  "fact",
+  "fix",
+  "focus",
+  "frame",
+  "idea",
+  "lesson",
+  "move",
+  "path",
+  "point",
+  "principle",
+  "priority",
+  "problem",
+  "question",
+  "result",
+  "rule",
+  "shift",
+  "signal",
+  "strategy",
+  "test",
+  "thing",
+  "tradeoff",
+  "truth",
+  "version",
+  "way",
+  "win"
+]);
+const VAGUE_FRAME_VERBS = new Set(["begins", "happens", "lives", "starts"]);
+const VAGUE_FRAME_LOCATIONS = new Set([
+  "downstream",
+  "earlier",
+  "here",
+  "there",
+  "upstream"
+]);
 const EVALUATION_TAILS = new Set([
   "boring",
   "clear",
@@ -78,15 +148,119 @@ function isDiscourseEvaluationSubject(
   return subject.some((word) => DISCOURSE_SUBJECT_HEADS.has(word));
 }
 
+function hasTail(words: readonly string[], tail: readonly string[]): boolean {
+  if (words.length < tail.length) {
+    return false;
+  }
+
+  const offset = words.length - tail.length;
+  return tail.every((word, index) => words[offset + index] === word);
+}
+
+function matchDiscourseWorkClaim(
+  words: readonly string[],
+  verbIndex: number,
+  subject: readonly string[]
+): string | undefined {
+  if (
+    verbIndex <= 0 ||
+    words[verbIndex] !== "is" ||
+    !DISCOURSE_SUBJECT_HEADS.has(subject.at(-1) ?? "")
+  ) {
+    return undefined;
+  }
+
+  const tail = DISCOURSE_WORK_TAILS.find((candidate) =>
+    hasTail(words, candidate)
+  );
+
+  return tail === undefined ? undefined : `is-${tail.join("-")}`;
+}
+
+function frameNounIndex(words: readonly string[]): number {
+  if (FRAME_NOUNS.has(words[1] ?? "")) {
+    return 1;
+  }
+
+  return FRAME_ADJECTIVES.has(words[1] ?? "") && FRAME_NOUNS.has(words[2] ?? "")
+    ? 2
+    : -1;
+}
+
+function matchWorthAttentionFrame(
+  words: readonly string[]
+): string | undefined {
+  if (words[0] !== "the") {
+    return undefined;
+  }
+
+  const nounIndex = frameNounIndex(words);
+  if (nounIndex < 0 || words[nounIndex + 1] !== "worth") {
+    return undefined;
+  }
+
+  const tail = words.slice(nounIndex + 2);
+  const matches =
+    tail[0] === "noticing" ||
+    tail[0] === "watching" ||
+    tail[0] === "tracking" ||
+    (tail[0] === "caring" && tail[1] === "about") ||
+    (tail[0] === "paying" && tail[1] === "attention" && tail[2] === "to");
+
+  return matches
+    ? `the-${words.slice(1, nounIndex + 1).join("-")}-worth-attention`
+    : undefined;
+}
+
+function matchVagueFrameLocation(words: readonly string[]): string | undefined {
+  const [first, adjective, noun, verb, location] = words;
+
+  return first === "the" &&
+    FRAME_ADJECTIVES.has(adjective ?? "") &&
+    FRAME_NOUNS.has(noun ?? "") &&
+    VAGUE_FRAME_VERBS.has(verb ?? "") &&
+    VAGUE_FRAME_LOCATIONS.has(location ?? "")
+    ? `the-${adjective ?? "useful"}-${noun ?? "frame"}-${verb ?? "starts"}-${location ?? "here"}`
+    : undefined;
+}
+
+function matchEvaluativeFrame(words: readonly string[]): string | undefined {
+  const [first, adjective, noun, verb] = words;
+
+  return first !== undefined &&
+    adjective !== undefined &&
+    noun !== undefined &&
+    verb !== undefined &&
+    DETERMINERS.has(first) &&
+    FRAME_ADJECTIVES.has(adjective) &&
+    FRAME_NOUNS.has(noun) &&
+    ["is", "are", "was"].includes(verb)
+    ? `the-${adjective}-${noun}-${verb}`
+    : undefined;
+}
+
+export function isAbstractAuditFrame(words: readonly string[]): boolean {
+  return words[0] === "the" && frameNounIndex(words) > 0
+    ? words[frameNounIndex(words)] === "audit"
+    : false;
+}
+
+export function matchExpandedDiscourseFrame(
+  words: readonly string[]
+): string | undefined {
+  return (
+    matchWorthAttentionFrame(words) ??
+    matchVagueFrameLocation(words) ??
+    matchEvaluativeFrame(words)
+  );
+}
+
 export function matchDiscourseEvaluationFrame(
   words: readonly string[]
 ): string | undefined {
   const [first] = words;
 
-  if (
-    words.length > 8 ||
-    !["the", "this", "that", "it"].includes(first ?? "")
-  ) {
+  if (words.length > 8) {
     return undefined;
   }
 
@@ -95,6 +269,15 @@ export function matchDiscourseEvaluationFrame(
   );
   const tail = words.at(-1);
   const subject = verbIndex > 0 ? words.slice(0, verbIndex) : [];
+
+  const workClaim = matchDiscourseWorkClaim(words, verbIndex, subject);
+  if (workClaim !== undefined) {
+    return workClaim;
+  }
+
+  if (!["the", "this", "that", "it"].includes(first ?? "")) {
+    return undefined;
+  }
 
   return verbIndex > 0 &&
     tail !== undefined &&

--- a/src/rules/syntactic-patterns/lead-ins/private/discourse-evaluation.ts
+++ b/src/rules/syntactic-patterns/lead-ins/private/discourse-evaluation.ts
@@ -148,15 +148,6 @@ function isDiscourseEvaluationSubject(
   return subject.some((word) => DISCOURSE_SUBJECT_HEADS.has(word));
 }
 
-function hasTail(words: readonly string[], tail: readonly string[]): boolean {
-  if (words.length < tail.length) {
-    return false;
-  }
-
-  const offset = words.length - tail.length;
-  return tail.every((word, index) => words[offset + index] === word);
-}
-
 function matchDiscourseWorkClaim(
   words: readonly string[],
   verbIndex: number,
@@ -171,7 +162,7 @@ function matchDiscourseWorkClaim(
   }
 
   const tail = DISCOURSE_WORK_TAILS.find((candidate) =>
-    hasTail(words, candidate)
+    candidate.every((word, index) => words[verbIndex + index + 1] === word)
   );
 
   return tail === undefined ? undefined : `is-${tail.join("-")}`;
@@ -215,7 +206,8 @@ function matchWorthAttentionFrame(
 function matchVagueFrameLocation(words: readonly string[]): string | undefined {
   const [first, adjective, noun, verb, location] = words;
 
-  return first === "the" &&
+  return words.length === 5 &&
+    first === "the" &&
     FRAME_ADJECTIVES.has(adjective ?? "") &&
     FRAME_NOUNS.has(noun ?? "") &&
     VAGUE_FRAME_VERBS.has(verb ?? "") &&
@@ -259,11 +251,6 @@ export function matchDiscourseEvaluationFrame(
   words: readonly string[]
 ): string | undefined {
   const [first] = words;
-
-  if (words.length > 8) {
-    return undefined;
-  }
-
   const verbIndex = words.findIndex((word) =>
     ABSTRACT_FRAME_VERBS.includes(word)
   );
@@ -273,6 +260,10 @@ export function matchDiscourseEvaluationFrame(
   const workClaim = matchDiscourseWorkClaim(words, verbIndex, subject);
   if (workClaim !== undefined) {
     return workClaim;
+  }
+
+  if (words.length > 8) {
+    return undefined;
   }
 
   if (!["the", "this", "that", "it"].includes(first ?? "")) {


### PR DESCRIPTION
## Summary

- broaden negation reframes across additional surface forms and factual guards
- expand formulaic signposting, affirmation, and empty-quantification detection
- fix reviewed boundary defects and add public hit/no-hit coverage
- publish package version 0.2.24

## Verification

- `pnpm run validate`
- `specular lint` and `specular verify`
- all 19 Fixture3 suites match approved behavior after excluding the known checkout-dependent `filePath` field
- adversarial review reports no remaining behavior blockers