### PR TITLE
Expand deictic evaluative signposting

### DIFF
--- a/.plans/2026-07-24-142849-deictic-evaluative-signposting.md
+++ b/.plans/2026-07-24-142849-deictic-evaluative-signposting.md
@@ -1,0 +1,82 @@
+# Goal
+
+Extend the existing `generic-signposting` rule to detect deictic evaluative
+frames that announce a judgment instead of stating the claim directly:
+
+- `Here is the odd part.`
+- `Here is a nice thing.`
+- `That is the best part.`
+- `Here's the strange bit: the result improved.`
+- `This was the surprising detail: sales rose as visits fell.`
+
+The matcher must generalize across openers, copular surface forms, evaluative
+adjectives, and discourse nouns. It must not become a literal phrase list or
+flag concrete identification such as `Here is the broken part inside the
+pump.`
+
+# Approach
+
+1. Add `matchDeicticEvaluativeFrame` to
+   `src/rules/syntactic-patterns/lead-ins/private/discourse-evaluation.ts`.
+2. Match four typed slots:
+   - opener: `here`, `this`, or `that`
+   - copula: `is`, `was`, or the normalized contractions `here's`, `this's`,
+     and `that's`
+   - determiner: `a`, `an`, or `the`
+   - evaluative adjective followed by a discourse noun
+3. Use an explicit evaluative-adjective set:
+   `best`, `better`, `biggest`, `central`, `core`, `crucial`, `funny`, `good`,
+   `great`, `hard`, `important`, `interesting`, `key`, `main`, `neat`, `nice`,
+   `odd`, `obvious`, `remarkable`, `strange`, `surprising`, `tricky`, `useful`,
+   `weird`, and `wild`.
+4. Use an explicit discourse-noun set:
+   `angle`, `aspect`, `bit`, `catch`, `detail`, `element`, `idea`, `part`,
+   `piece`, `point`, `thing`, and `twist`.
+5. Call the matcher from `matchExpandedDiscourseFrame`. In
+   `generic-signposting.ts`, keep this frame active when a trailing clause
+   contains concrete evidence; the unnecessary signpost remains the target.
+   Preserve the existing public rule ID, reporting path, and one-to-one policy.
+6. Add isolated hit cases for combinations of every slot category and
+   adversarial no-hit cases for concrete adjectives, concrete nouns, and
+   allowed adjective-noun pairs that continue into concrete identification.
+7. Add the reviewed cases to coherent paragraphs in
+   `behavior/fixtures/textlint-rules/corpus/engineering-review.md` and update
+   its preserve list.
+8. Use Fixture3 to review the syntactic-pattern case and engineering-review
+   corpus diffs. Approve only the intended new `generic-signposting` findings.
+9. Bump the package patch version to `0.2.27`, validate, merge through a pull
+   request, publish from GitHub Actions, and install the published version
+   locally.
+10. Remove the Fixture3 parallel-build race exposed by repository-wide
+    verification. Compile each behavior replay into its own temporary output
+    directory instead of deleting and rebuilding shared `dist/`.
+
+# Key Decisions
+
+- This is an existing generic-signposting behavior, not a new rule or family.
+- The discourse noun is a slot. The matcher is not restricted to `part`.
+- Evaluative adjectives are explicit because accepting every adjective would
+  flag concrete identification such as `broken part` and `replacement piece`.
+- `there` is excluded because `There is the broken part` is predominantly
+  locative rather than signposting.
+- Trailing clauses and colon explanations do not suppress the frame. The
+  signpost remains redundant even when a concrete claim follows it.
+- A space after the matched noun means the noun phrase continues, so the
+  matcher does not report it. Sentence-ending punctuation and punctuation
+  that introduces an explanation remain reportable boundaries.
+- Existing concrete-evidence suppression does not apply to this frame because
+  the target is the unnecessary evaluative lead-in itself.
+
+# Files To Modify
+
+- `src/rules/syntactic-patterns/lead-ins/private/discourse-evaluation.ts`
+- `src/rules/syntactic-patterns/lead-ins/generic-signposting.ts`
+- `behavior/fixtures/textlint-rules/cases/syntactic-patterns/hits.md`
+- `behavior/fixtures/textlint-rules/cases/syntactic-patterns/no-hits.md`
+- `behavior/fixtures/textlint-rules/corpus/engineering-review.md`
+- `behavior/fixtures/textlint-rules/corpus/engineering-review.preserve.json`
+- `behavior/golden/textlint-rules-cases-syntactic-patterns/`
+- `behavior/golden/textlint-rules-corpus-engineering-review/`
+- `package.json`
+- `scripts/behavior-replay.sh`
+- This plan, its Specular specification and coverage map, and the worklog

--- a/.plans/2026-07-24-142849-deictic-evaluative-signposting.md.spec.coverage.md
+++ b/.plans/2026-07-24-142849-deictic-evaluative-signposting.md.spec.coverage.md
@@ -1,0 +1,36 @@
+# Coverage Map
+
+## Goal
+
+- Matcher structure and slot values:
+  `requirements.content[0]`
+- Public hit and no-hit behavior: Fixture3 suite
+  `textlint-rules-cases-syntactic-patterns`
+
+## Approach
+
+- Steps 1-5: `requirements.content[0]`, `requirements.content[1]`
+- Step 6: `requirements.content[2]`, `requirements.content[3]`, and Fixture3
+  suite `textlint-rules-cases-syntactic-patterns`
+- Step 7: `requirements.content[4]`, `requirements.content[5]`, and Fixture3
+  suite `textlint-rules-corpus-engineering-review`
+- Step 8: Fixture3 suites `textlint-rules-cases-syntactic-patterns` and
+  `textlint-rules-corpus-engineering-review`
+- Step 9: `requirements.content[6]`; pull request, GitHub Actions, npm
+  publication, and local installation are external verification
+- Step 10: `requirements.content[7]` and `fixture3 check --all`
+
+## Key Decisions
+
+- Existing rule ownership and one-to-one reporting: Fixture3 rule IDs
+- Discourse-noun slot and explicit adjective boundary:
+  `requirements.content[0]`
+- Excluded `there`, concrete adjective controls, and no concrete-evidence
+  suppression: Fixture3 hit and no-hit behavior
+
+## Files To Modify
+
+- Required repository paths: `requirements.tree`
+- Behavioral contents: `requirements.content[2]` through
+  `requirements.content[5]`
+- Release metadata: `requirements.content[6]`

--- a/.plans/2026-07-24-142849-deictic-evaluative-signposting.md.spec.json
+++ b/.plans/2026-07-24-142849-deictic-evaluative-signposting.md.spec.json
@@ -1,0 +1,177 @@
+{
+  "version": 4,
+  "requirements": {
+    "tree": {
+      "verifier": ["builtin:tree"],
+      "reason": "Plan: implementation, fixtures, corpus, approved behavior, release metadata, and development records",
+      "required": [
+        "src/rules/syntactic-patterns/lead-ins/private/discourse-evaluation.ts",
+        "src/rules/syntactic-patterns/lead-ins/generic-signposting.ts",
+        "behavior/fixtures/textlint-rules/cases/syntactic-patterns/hits.md",
+        "behavior/fixtures/textlint-rules/cases/syntactic-patterns/no-hits.md",
+        "behavior/fixtures/textlint-rules/corpus/engineering-review.md",
+        "behavior/fixtures/textlint-rules/corpus/engineering-review.preserve.json",
+        "behavior/golden/textlint-rules-cases-syntactic-patterns/approved.normalized.json",
+        "behavior/golden/textlint-rules-cases-syntactic-patterns/approved.meta.json",
+        "behavior/golden/textlint-rules-corpus-engineering-review/approved.normalized.json",
+        "behavior/golden/textlint-rules-corpus-engineering-review/approved.meta.json",
+        "package.json",
+        "scripts/behavior-replay.sh",
+        ".plans/2026-07-24-142849-deictic-evaluative-signposting.md",
+        ".plans/2026-07-24-142849-deictic-evaluative-signposting.md.spec.json",
+        ".plans/2026-07-24-142849-deictic-evaluative-signposting.md.spec.coverage.md",
+        ".worklogs/2026-07-24-151127-deictic-evaluative-signposting.md"
+      ]
+    },
+    "content": [
+      {
+        "verifier": ["builtin:content"],
+        "files": [
+          "src/rules/syntactic-patterns/lead-ins/private/discourse-evaluation.ts"
+        ],
+        "reason": "Approach 1-5: add and compose the generalized private matcher with every declared slot value",
+        "required": [
+          "function matchDeicticEvaluativeFrame(",
+          "matchDeicticEvaluativeFrame(text, words)",
+          "text.at(frame.length)",
+          "\"here\"",
+          "\"this\"",
+          "\"that\"",
+          "\"is\"",
+          "\"was\"",
+          "\"here's\"",
+          "\"this's\"",
+          "\"that's\"",
+          "\"a\"",
+          "\"an\"",
+          "\"the\"",
+          "\"best\"",
+          "\"better\"",
+          "\"biggest\"",
+          "\"central\"",
+          "\"core\"",
+          "\"crucial\"",
+          "\"funny\"",
+          "\"good\"",
+          "\"great\"",
+          "\"hard\"",
+          "\"important\"",
+          "\"interesting\"",
+          "\"key\"",
+          "\"main\"",
+          "\"neat\"",
+          "\"nice\"",
+          "\"odd\"",
+          "\"obvious\"",
+          "\"remarkable\"",
+          "\"strange\"",
+          "\"surprising\"",
+          "\"tricky\"",
+          "\"useful\"",
+          "\"weird\"",
+          "\"wild\"",
+          "\"angle\"",
+          "\"aspect\"",
+          "\"bit\"",
+          "\"catch\"",
+          "\"detail\"",
+          "\"element\"",
+          "\"idea\"",
+          "\"part\"",
+          "\"piece\"",
+          "\"point\"",
+          "\"thing\"",
+          "\"twist\""
+        ],
+        "forbidden": ["export function matchDeicticEvaluativeFrame("]
+      },
+      {
+        "verifier": ["builtin:content"],
+        "files": [
+          "src/rules/syntactic-patterns/lead-ins/generic-signposting.ts"
+        ],
+        "reason": "Approach 5: trailing concrete evidence does not suppress this signposting frame",
+        "required": ["abstract.startsWith(\"deictic-evaluative-\")"]
+      },
+      {
+        "verifier": ["builtin:content"],
+        "files": [
+          "behavior/fixtures/textlint-rules/cases/syntactic-patterns/hits.md"
+        ],
+        "reason": "Approach 6: isolated hit coverage spans the declared slots",
+        "required": [
+          "Here is the odd part.",
+          "Here is a nice thing.",
+          "That is the best part.",
+          "Here's the strange bit: the result improved.",
+          "This was the surprising detail: sales rose as visits fell."
+        ]
+      },
+      {
+        "verifier": ["builtin:content"],
+        "files": [
+          "behavior/fixtures/textlint-rules/cases/syntactic-patterns/no-hits.md"
+        ],
+        "reason": "Approach 6: concrete identification remains clean",
+        "required": [
+          "Here is the broken part inside the pump.",
+          "Here is the best part of the movie.",
+          "That is a remarkable piece of Renaissance sculpture.",
+          "This is the important point on the map.",
+          "Here is the key element in the periodic table."
+        ]
+      },
+      {
+        "verifier": ["builtin:content"],
+        "files": [
+          "behavior/fixtures/textlint-rules/corpus/engineering-review.md"
+        ],
+        "reason": "Approach 7: reviewed hit forms appear in coherent corpus prose",
+        "exists": [
+          "Here is the odd part.",
+          "Here is a nice thing.",
+          "That is the best part.",
+          "Here's the strange bit:",
+          "This was the surprising detail:"
+        ]
+      },
+      {
+        "verifier": ["builtin:content"],
+        "files": [
+          "behavior/fixtures/textlint-rules/corpus/engineering-review.preserve.json"
+        ],
+        "reason": "Approach 7: the preserve data records every reviewed hit form",
+        "exists": [
+          "Here is the odd part.",
+          "Here is a nice thing.",
+          "That is the best part.",
+          "Here's the strange bit:",
+          "This was the surprising detail:"
+        ]
+      },
+      {
+        "verifier": ["builtin:content"],
+        "files": ["package.json"],
+        "reason": "Approach 9: patch release version",
+        "required": ["\"version\": \"0.2.27\""],
+        "forbidden": ["\"version\": \"0.2.26\""]
+      },
+      {
+        "verifier": ["builtin:content"],
+        "files": ["scripts/behavior-replay.sh"],
+        "reason": "Approach 10: each parallel Fixture3 suite compiles into isolated temporary output",
+        "required": [
+          "mkdir -p \"$ROOT/.fixture3\"",
+          "TMP_DIR=\"$(mktemp -d \"$ROOT/.fixture3/replay.XXXXXX\")\"",
+          "RULES_ROOT=\"$TMP_DIR/dist/rules\"",
+          "--outDir \"$TMP_DIR/dist\"",
+          "--rulesdir \"$RULES_ROOT/phrases\""
+        ],
+        "forbidden": [
+          "pnpm run build >/dev/null",
+          "--rulesdir \"$ROOT/dist/rules/phrases\""
+        ]
+      }
+    ]
+  }
+}

--- a/.worklogs/2026-07-24-151127-deictic-evaluative-signposting.md
+++ b/.worklogs/2026-07-24-151127-deictic-evaluative-signposting.md
@@ -1,0 +1,42 @@
+# Summary
+
+Extended `generic-signposting` with a generalized deictic evaluative frame.
+The rule now catches forms such as `Here is the odd part`, `Here is a nice
+thing`, and `That is the best part` across explicit adjective and
+discourse-noun slots.
+
+# Decisions Made
+
+- Kept the existing `generic-signposting` rule ID and one-to-one reporting.
+- Matched `here`, `this`, and `that`, including normalized contractions and
+  present or past copulas.
+- Used explicit evaluative adjectives and discourse nouns. Accepting every
+  adjective would misclassify concrete identification such as `broken part`.
+- Required the matched noun to end at punctuation or the end of the sentence.
+  This keeps allowed slots clean inside concrete phrases such as `the best
+  part of the movie`.
+- Kept the frame active when a colon explanation contains concrete evidence
+  because the unnecessary signpost remains the target.
+- Added 14 isolated hit cases and 12 concrete no-hit controls, then placed
+  all 22 cases in coherent engineering-review corpus prose and preserve data.
+- Reviewed Fixture3 changes before approval. Cases added 14
+  `generic-signposting` findings and zero no-hit findings. The corpus added the
+  same 14 findings and no unrelated findings.
+- Fixed the Fixture3 parallel-build race by compiling each suite into an
+  isolated temporary directory instead of deleting shared `dist/`.
+- Bumped the package patch version to `0.2.27`.
+
+# Key Files
+
+- `.plans/2026-07-24-142849-deictic-evaluative-signposting.md`
+- `src/rules/syntactic-patterns/lead-ins/private/discourse-evaluation.ts`
+- `src/rules/syntactic-patterns/lead-ins/generic-signposting.ts`
+- `behavior/fixtures/textlint-rules/cases/syntactic-patterns/`
+- `behavior/fixtures/textlint-rules/corpus/engineering-review.md`
+- `behavior/fixtures/textlint-rules/corpus/engineering-review.preserve.json`
+- `scripts/behavior-replay.sh`
+
+# Next Steps
+
+- Merge after the required CI and CodeQL checks pass.
+- Publish and install `slopless@0.2.27`.

--- a/behavior/fixtures/textlint-rules/cases/syntactic-patterns/hits.md
+++ b/behavior/fixtures/textlint-rules/cases/syntactic-patterns/hits.md
@@ -1467,3 +1467,31 @@ It shouldn't guess. It follows the ranking.
 It won't inspect pages. It reads attributes.
 
 It wouldn't inspect pages. It reads product records.
+
+Here is the odd part.
+
+Here is a nice thing.
+
+That is the best part.
+
+Here's the strange bit: the result improved.
+
+This was the surprising detail: sales rose as visits fell.
+
+This is the useful point: every retry repeats the same request.
+
+That's the tricky aspect: the faster path loses more records.
+
+That was the funny twist.
+
+Here's a great idea.
+
+This is the key element.
+
+That is a remarkable piece.
+
+Here is the interesting angle.
+
+This is the obvious catch.
+
+Here is an important aspect.

--- a/behavior/fixtures/textlint-rules/cases/syntactic-patterns/no-hits.md
+++ b/behavior/fixtures/textlint-rules/cases/syntactic-patterns/no-hits.md
@@ -569,3 +569,27 @@ The motor wouldn't start. It started after the battery was replaced.
 Nobody reads the manual anymore. An AI reads the warning in the manual.
 
 The agent wasn't ranking pages. It had never visited Lisbon.
+
+Here is the broken part inside the pump.
+
+Here is the replacement part for the pump.
+
+That is the upper section of the bracket.
+
+This is a stainless steel piece from the old assembly.
+
+Here is the stamped detail on the housing.
+
+That is a red thing from the parts bin.
+
+There is the best part on the workbench.
+
+Here is the largest bearing in the gearbox.
+
+Here is the best part of the movie.
+
+That is a remarkable piece of Renaissance sculpture.
+
+This is the important point on the map.
+
+Here is the key element in the periodic table.

--- a/behavior/fixtures/textlint-rules/corpus/engineering-review.md
+++ b/behavior/fixtures/textlint-rules/corpus/engineering-review.md
@@ -1097,3 +1097,25 @@ Literal reactions named materials and tools rather than personal responses. Here
 The remaining pairs supplied causes or changed the object of the claim. The motor wouldn't start. It started after the battery was replaced.
 
 Nobody reads the manual anymore. An AI reads the warning in the manual. The agent wasn't ranking pages. It had never visited Lisbon.
+
+## Evaluative signposting review
+
+The draft kept announcing its judgments before giving the evidence. Here is the odd part. Brand visits fell, yet sales rates rose. Here is a nice thing. The corrected export preserved every product identifier.
+
+The reviewer found another empty judgment in the conclusion. That is the best part. The result survived a second run without manual cleanup.
+
+The same habit appeared across punctuation and tense. Here's the strange bit: the result improved. This was the surprising detail: sales rose as visits fell. This is the useful point: every retry repeats the same request.
+
+The next section used the same frame for a constraint and a result. That's the tricky aspect: the faster path loses more records. That was the funny twist.
+
+The reviewer found the pattern with other judgment words and nouns. Here's a great idea. This is the key element. That is a remarkable piece.
+
+The remaining draft lines changed the noun but not the function. Here is the interesting angle. This is the obvious catch. Here is an important aspect. Each sentence delayed the claim it was supposed to make.
+
+Concrete identification remained useful during the hardware inspection. Here is the broken part inside the pump. Here is the replacement part for the pump. That is the upper section of the bracket.
+
+The technician continued by naming materials and locations. This is a stainless steel piece from the old assembly. Here is the stamped detail on the housing. That is a red thing from the parts bin.
+
+The last two lines pointed to objects on the bench. There is the best part on the workbench. Here is the largest bearing in the gearbox.
+
+The review closed with four ordinary identifications that reused the allowed adjective and noun slots. Here is the best part of the movie. That is a remarkable piece of Renaissance sculpture. This is the important point on the map. Here is the key element in the periodic table.

--- a/behavior/fixtures/textlint-rules/corpus/engineering-review.preserve.json
+++ b/behavior/fixtures/textlint-rules/corpus/engineering-review.preserve.json
@@ -4341,6 +4341,188 @@
       "bucket": "no-hits",
       "source": "cases/syntactic-patterns/no-hits.md",
       "line": 571
+    },
+    {
+      "text": "Here is the odd part.",
+      "family": "syntactic-patterns",
+      "bucket": "hits",
+      "source": "cases/syntactic-patterns/hits.md",
+      "line": 1471
+    },
+    {
+      "text": "Here is a nice thing.",
+      "family": "syntactic-patterns",
+      "bucket": "hits",
+      "source": "cases/syntactic-patterns/hits.md",
+      "line": 1473
+    },
+    {
+      "text": "That is the best part.",
+      "family": "syntactic-patterns",
+      "bucket": "hits",
+      "source": "cases/syntactic-patterns/hits.md",
+      "line": 1475
+    },
+    {
+      "text": "Here's the strange bit: the result improved.",
+      "family": "syntactic-patterns",
+      "bucket": "hits",
+      "source": "cases/syntactic-patterns/hits.md",
+      "line": 1477
+    },
+    {
+      "text": "This was the surprising detail: sales rose as visits fell.",
+      "family": "syntactic-patterns",
+      "bucket": "hits",
+      "source": "cases/syntactic-patterns/hits.md",
+      "line": 1479
+    },
+    {
+      "text": "This is the useful point: every retry repeats the same request.",
+      "family": "syntactic-patterns",
+      "bucket": "hits",
+      "source": "cases/syntactic-patterns/hits.md",
+      "line": 1481
+    },
+    {
+      "text": "That's the tricky aspect: the faster path loses more records.",
+      "family": "syntactic-patterns",
+      "bucket": "hits",
+      "source": "cases/syntactic-patterns/hits.md",
+      "line": 1483
+    },
+    {
+      "text": "That was the funny twist.",
+      "family": "syntactic-patterns",
+      "bucket": "hits",
+      "source": "cases/syntactic-patterns/hits.md",
+      "line": 1485
+    },
+    {
+      "text": "Here's a great idea.",
+      "family": "syntactic-patterns",
+      "bucket": "hits",
+      "source": "cases/syntactic-patterns/hits.md",
+      "line": 1487
+    },
+    {
+      "text": "This is the key element.",
+      "family": "syntactic-patterns",
+      "bucket": "hits",
+      "source": "cases/syntactic-patterns/hits.md",
+      "line": 1489
+    },
+    {
+      "text": "That is a remarkable piece.",
+      "family": "syntactic-patterns",
+      "bucket": "hits",
+      "source": "cases/syntactic-patterns/hits.md",
+      "line": 1491
+    },
+    {
+      "text": "Here is the interesting angle.",
+      "family": "syntactic-patterns",
+      "bucket": "hits",
+      "source": "cases/syntactic-patterns/hits.md",
+      "line": 1493
+    },
+    {
+      "text": "This is the obvious catch.",
+      "family": "syntactic-patterns",
+      "bucket": "hits",
+      "source": "cases/syntactic-patterns/hits.md",
+      "line": 1495
+    },
+    {
+      "text": "Here is an important aspect.",
+      "family": "syntactic-patterns",
+      "bucket": "hits",
+      "source": "cases/syntactic-patterns/hits.md",
+      "line": 1497
+    },
+    {
+      "text": "Here is the broken part inside the pump.",
+      "family": "syntactic-patterns",
+      "bucket": "no-hits",
+      "source": "cases/syntactic-patterns/no-hits.md",
+      "line": 573
+    },
+    {
+      "text": "Here is the replacement part for the pump.",
+      "family": "syntactic-patterns",
+      "bucket": "no-hits",
+      "source": "cases/syntactic-patterns/no-hits.md",
+      "line": 575
+    },
+    {
+      "text": "That is the upper section of the bracket.",
+      "family": "syntactic-patterns",
+      "bucket": "no-hits",
+      "source": "cases/syntactic-patterns/no-hits.md",
+      "line": 577
+    },
+    {
+      "text": "This is a stainless steel piece from the old assembly.",
+      "family": "syntactic-patterns",
+      "bucket": "no-hits",
+      "source": "cases/syntactic-patterns/no-hits.md",
+      "line": 579
+    },
+    {
+      "text": "Here is the stamped detail on the housing.",
+      "family": "syntactic-patterns",
+      "bucket": "no-hits",
+      "source": "cases/syntactic-patterns/no-hits.md",
+      "line": 581
+    },
+    {
+      "text": "That is a red thing from the parts bin.",
+      "family": "syntactic-patterns",
+      "bucket": "no-hits",
+      "source": "cases/syntactic-patterns/no-hits.md",
+      "line": 583
+    },
+    {
+      "text": "There is the best part on the workbench.",
+      "family": "syntactic-patterns",
+      "bucket": "no-hits",
+      "source": "cases/syntactic-patterns/no-hits.md",
+      "line": 585
+    },
+    {
+      "text": "Here is the largest bearing in the gearbox.",
+      "family": "syntactic-patterns",
+      "bucket": "no-hits",
+      "source": "cases/syntactic-patterns/no-hits.md",
+      "line": 587
+    },
+    {
+      "text": "Here is the best part of the movie.",
+      "family": "syntactic-patterns",
+      "bucket": "no-hits",
+      "source": "cases/syntactic-patterns/no-hits.md",
+      "line": 589
+    },
+    {
+      "text": "That is a remarkable piece of Renaissance sculpture.",
+      "family": "syntactic-patterns",
+      "bucket": "no-hits",
+      "source": "cases/syntactic-patterns/no-hits.md",
+      "line": 591
+    },
+    {
+      "text": "This is the important point on the map.",
+      "family": "syntactic-patterns",
+      "bucket": "no-hits",
+      "source": "cases/syntactic-patterns/no-hits.md",
+      "line": 593
+    },
+    {
+      "text": "Here is the key element in the periodic table.",
+      "family": "syntactic-patterns",
+      "bucket": "no-hits",
+      "source": "cases/syntactic-patterns/no-hits.md",
+      "line": 595
     }
   ]
 }

--- a/behavior/golden/textlint-rules-cases-syntactic-patterns/approved.meta.json
+++ b/behavior/golden/textlint-rules-cases-syntactic-patterns/approved.meta.json
@@ -1,27 +1,27 @@
 {
   "suite": "textlint-rules-cases-syntactic-patterns",
   "kind": "approved",
-  "run_id": "2026-07-24T10-31-40.625913Z-04547efb",
-  "run_commit": "ddf8160",
+  "run_id": "2026-07-24T14-55-15.344624Z-04547efb",
+  "run_commit": "88996f4",
   "working_tree": "dirty",
-  "recorded_at": "2026-07-24T10:31:40.625913Z",
-  "fixture_hash": "sha256:e4d28f9f73682ee3bf2a5d2c61f9b6115274222864c3ce45d7216dc8405501cd",
+  "recorded_at": "2026-07-24T14:55:15.344624Z",
+  "fixture_hash": "sha256:a83b3c8fb281042574496aba3f27e12bfab9d440663f9fbb3b212edd5c00375d",
   "manifest_hash": "sha256:04547efbb13157ee3d8ef18dda767231fd63d3f9cc27c15317cf28c5f0583e7b",
   "tool_version": "0.1.8",
   "output_schema_version": "1",
   "fixtures": [
     {
       "path": "behavior/fixtures/textlint-rules/cases/syntactic-patterns/hits.md",
-      "sha256": "sha256:cc807cc0d82630bc280dfc421a97c7f836a849119022f2225bd8132ee1ec8e0a"
+      "sha256": "sha256:d23bc8684eb55d2e821aa0605719a033df3b913e3ac8a0eda1ef94d44889da34"
     },
     {
       "path": "behavior/fixtures/textlint-rules/cases/syntactic-patterns/no-hits.md",
-      "sha256": "sha256:5c82c3ce56e614c68b05cf3d3472e756eb051ff4843c946c13a5643930a1efca"
+      "sha256": "sha256:f050f76da441343720ebe88642c6e74c1a826d8630c72e20b19deb78d0ec63e9"
     },
     {
       "path": "behavior/fixtures/textlint-rules/cases/syntactic-patterns/significance-density.md",
       "sha256": "sha256:a5489177104e3714ea3558c1d90bdd91573bf719c83112225ae9e9b0e288c6da"
     }
   ],
-  "comment": "Normalize fixture paths relative to repository; findings unchanged"
+  "comment": "Add reviewed deictic evaluative signposting slots and concrete continuation controls"
 }

--- a/behavior/golden/textlint-rules-cases-syntactic-patterns/approved.normalized.json
+++ b/behavior/golden/textlint-rules-cases-syntactic-patterns/approved.normalized.json
@@ -16,7 +16,7 @@
             "line": 1
           }
         },
-        "message": "Flesch Reading Ease is 51.01. Keep it at 61 or higher.",
+        "message": "Flesch Reading Ease is 50.8. Keep it at 61 or higher.",
         "range": [
           0,
           1
@@ -39,7 +39,7 @@
             "line": 1
           }
         },
-        "message": "Gunning Fog is 13.78. Keep it at 12 or lower.",
+        "message": "Gunning Fog is 13.85. Keep it at 12 or lower.",
         "range": [
           0,
           1
@@ -17297,6 +17297,328 @@
         "ruleId": "negation-reframe",
         "severity": 2,
         "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 61167,
+        "line": 1471,
+        "loc": {
+          "end": {
+            "column": 22,
+            "line": 1471
+          },
+          "start": {
+            "column": 1,
+            "line": 1471
+          }
+        },
+        "message": "Generic signposting found: deictic-evaluative-here-odd-part. Replace the frame with the concrete claim.",
+        "range": [
+          61167,
+          61188
+        ],
+        "ruleId": "generic-signposting",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 61190,
+        "line": 1473,
+        "loc": {
+          "end": {
+            "column": 22,
+            "line": 1473
+          },
+          "start": {
+            "column": 1,
+            "line": 1473
+          }
+        },
+        "message": "Generic signposting found: deictic-evaluative-here-nice-thing. Replace the frame with the concrete claim.",
+        "range": [
+          61190,
+          61211
+        ],
+        "ruleId": "generic-signposting",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 61213,
+        "line": 1475,
+        "loc": {
+          "end": {
+            "column": 23,
+            "line": 1475
+          },
+          "start": {
+            "column": 1,
+            "line": 1475
+          }
+        },
+        "message": "Generic signposting found: deictic-evaluative-that-best-part. Replace the frame with the concrete claim.",
+        "range": [
+          61213,
+          61235
+        ],
+        "ruleId": "generic-signposting",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 61237,
+        "line": 1477,
+        "loc": {
+          "end": {
+            "column": 45,
+            "line": 1477
+          },
+          "start": {
+            "column": 1,
+            "line": 1477
+          }
+        },
+        "message": "Generic signposting found: deictic-evaluative-here-strange-bit. Replace the frame with the concrete claim.",
+        "range": [
+          61237,
+          61281
+        ],
+        "ruleId": "generic-signposting",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 61283,
+        "line": 1479,
+        "loc": {
+          "end": {
+            "column": 59,
+            "line": 1479
+          },
+          "start": {
+            "column": 1,
+            "line": 1479
+          }
+        },
+        "message": "Generic signposting found: deictic-evaluative-this-surprising-detail. Replace the frame with the concrete claim.",
+        "range": [
+          61283,
+          61341
+        ],
+        "ruleId": "generic-signposting",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 61343,
+        "line": 1481,
+        "loc": {
+          "end": {
+            "column": 64,
+            "line": 1481
+          },
+          "start": {
+            "column": 1,
+            "line": 1481
+          }
+        },
+        "message": "Generic signposting found: deictic-evaluative-this-useful-point. Replace the frame with the concrete claim.",
+        "range": [
+          61343,
+          61406
+        ],
+        "ruleId": "generic-signposting",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 61408,
+        "line": 1483,
+        "loc": {
+          "end": {
+            "column": 62,
+            "line": 1483
+          },
+          "start": {
+            "column": 1,
+            "line": 1483
+          }
+        },
+        "message": "Generic signposting found: deictic-evaluative-that-tricky-aspect. Replace the frame with the concrete claim.",
+        "range": [
+          61408,
+          61469
+        ],
+        "ruleId": "generic-signposting",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 61471,
+        "line": 1485,
+        "loc": {
+          "end": {
+            "column": 26,
+            "line": 1485
+          },
+          "start": {
+            "column": 1,
+            "line": 1485
+          }
+        },
+        "message": "Generic signposting found: deictic-evaluative-that-funny-twist. Replace the frame with the concrete claim.",
+        "range": [
+          61471,
+          61496
+        ],
+        "ruleId": "generic-signposting",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 61498,
+        "line": 1487,
+        "loc": {
+          "end": {
+            "column": 21,
+            "line": 1487
+          },
+          "start": {
+            "column": 1,
+            "line": 1487
+          }
+        },
+        "message": "Generic signposting found: deictic-evaluative-here-great-idea. Replace the frame with the concrete claim.",
+        "range": [
+          61498,
+          61518
+        ],
+        "ruleId": "generic-signposting",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 61520,
+        "line": 1489,
+        "loc": {
+          "end": {
+            "column": 25,
+            "line": 1489
+          },
+          "start": {
+            "column": 1,
+            "line": 1489
+          }
+        },
+        "message": "Generic signposting found: deictic-evaluative-this-key-element. Replace the frame with the concrete claim.",
+        "range": [
+          61520,
+          61544
+        ],
+        "ruleId": "generic-signposting",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 61546,
+        "line": 1491,
+        "loc": {
+          "end": {
+            "column": 28,
+            "line": 1491
+          },
+          "start": {
+            "column": 1,
+            "line": 1491
+          }
+        },
+        "message": "Generic signposting found: deictic-evaluative-that-remarkable-piece. Replace the frame with the concrete claim.",
+        "range": [
+          61546,
+          61573
+        ],
+        "ruleId": "generic-signposting",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 61575,
+        "line": 1493,
+        "loc": {
+          "end": {
+            "column": 31,
+            "line": 1493
+          },
+          "start": {
+            "column": 1,
+            "line": 1493
+          }
+        },
+        "message": "Generic signposting found: deictic-evaluative-here-interesting-angle. Replace the frame with the concrete claim.",
+        "range": [
+          61575,
+          61605
+        ],
+        "ruleId": "generic-signposting",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 61607,
+        "line": 1495,
+        "loc": {
+          "end": {
+            "column": 27,
+            "line": 1495
+          },
+          "start": {
+            "column": 1,
+            "line": 1495
+          }
+        },
+        "message": "Generic signposting found: deictic-evaluative-this-obvious-catch. Replace the frame with the concrete claim.",
+        "range": [
+          61607,
+          61633
+        ],
+        "ruleId": "generic-signposting",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 61635,
+        "line": 1497,
+        "loc": {
+          "end": {
+            "column": 29,
+            "line": 1497
+          },
+          "start": {
+            "column": 1,
+            "line": 1497
+          }
+        },
+        "message": "Generic signposting found: deictic-evaluative-here-important-aspect. Replace the frame with the concrete claim.",
+        "range": [
+          61635,
+          61663
+        ],
+        "ruleId": "generic-signposting",
+        "severity": 2,
+        "type": "lint"
       }
     ]
   },
@@ -17317,7 +17639,7 @@
             "line": 1
           }
         },
-        "message": "Flesch Reading Ease is 47.86. Keep it at 61 or higher.",
+        "message": "Flesch Reading Ease is 46.95. Keep it at 61 or higher.",
         "range": [
           0,
           1
@@ -17340,7 +17662,7 @@
             "line": 1
           }
         },
-        "message": "Gunning Fog is 15.24. Keep it at 12 or lower.",
+        "message": "Gunning Fog is 15.59. Keep it at 12 or lower.",
         "range": [
           0,
           1

--- a/behavior/golden/textlint-rules-corpus-engineering-review/approved.meta.json
+++ b/behavior/golden/textlint-rules-corpus-engineering-review/approved.meta.json
@@ -1,19 +1,19 @@
 {
   "suite": "textlint-rules-corpus-engineering-review",
   "kind": "approved",
-  "run_id": "2026-07-24T10-32-20.936627Z-04547efb",
-  "run_commit": "ddf8160",
+  "run_id": "2026-07-24T14-55-24.369937Z-04547efb",
+  "run_commit": "88996f4",
   "working_tree": "dirty",
-  "recorded_at": "2026-07-24T10:32:20.936627Z",
-  "fixture_hash": "sha256:db5d4265ceb88ebd306f135cea61456d51ce3b4e086e2aa29cac943aea3c5ddf",
+  "recorded_at": "2026-07-24T14:55:24.369937Z",
+  "fixture_hash": "sha256:f7253355ba97e0677795b4e1c3727d09062244d496ec56c04d7026e532734aee",
   "manifest_hash": "sha256:04547efbb13157ee3d8ef18dda767231fd63d3f9cc27c15317cf28c5f0583e7b",
   "tool_version": "0.1.8",
   "output_schema_version": "1",
   "fixtures": [
     {
       "path": "behavior/fixtures/textlint-rules/corpus/engineering-review.md",
-      "sha256": "sha256:beac52b45d169e86f94840b7ee3c2b856066961d2027d9af90176d4717fa029c"
+      "sha256": "sha256:91a88819a89c7866df076116a77ecd1dfaa4a6afcb7c8a0ab34d9f06cabc4be9"
     }
   ],
-  "comment": "Normalize fixture paths relative to repository; findings unchanged"
+  "comment": "Add coherent deictic evaluative signposting and concrete continuation coverage"
 }

--- a/behavior/golden/textlint-rules-corpus-engineering-review/approved.normalized.json
+++ b/behavior/golden/textlint-rules-corpus-engineering-review/approved.normalized.json
@@ -16,7 +16,7 @@
             "line": 1
           }
         },
-        "message": "Flesch Reading Ease is 54.76. Keep it at 61 or higher.",
+        "message": "Flesch Reading Ease is 55.88. Keep it at 61 or higher.",
         "range": [
           0,
           1
@@ -39,7 +39,7 @@
             "line": 1
           }
         },
-        "message": "Gunning Fog is 12.49. Keep it at 12 or lower.",
+        "message": "Gunning Fog is 12.01. Keep it at 12 or lower.",
         "range": [
           0,
           1
@@ -10510,6 +10510,328 @@
           49425
         ],
         "ruleId": "word-repetition",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 69,
+        "index": 50294,
+        "line": 1103,
+        "loc": {
+          "end": {
+            "column": 90,
+            "line": 1103
+          },
+          "start": {
+            "column": 69,
+            "line": 1103
+          }
+        },
+        "message": "Generic signposting found: deictic-evaluative-here-odd-part. Replace the frame with the concrete claim.",
+        "range": [
+          50294,
+          50315
+        ],
+        "ruleId": "generic-signposting",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 132,
+        "index": 50357,
+        "line": 1103,
+        "loc": {
+          "end": {
+            "column": 153,
+            "line": 1103
+          },
+          "start": {
+            "column": 132,
+            "line": 1103
+          }
+        },
+        "message": "Generic signposting found: deictic-evaluative-here-nice-thing. Replace the frame with the concrete claim.",
+        "range": [
+          50357,
+          50378
+        ],
+        "ruleId": "generic-signposting",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 62,
+        "index": 50498,
+        "line": 1105,
+        "loc": {
+          "end": {
+            "column": 84,
+            "line": 1105
+          },
+          "start": {
+            "column": 62,
+            "line": 1105
+          }
+        },
+        "message": "Generic signposting found: deictic-evaluative-that-best-part. Replace the frame with the concrete claim.",
+        "range": [
+          50498,
+          50520
+        ],
+        "ruleId": "generic-signposting",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 55,
+        "index": 50633,
+        "line": 1107,
+        "loc": {
+          "end": {
+            "column": 99,
+            "line": 1107
+          },
+          "start": {
+            "column": 55,
+            "line": 1107
+          }
+        },
+        "message": "Generic signposting found: deictic-evaluative-here-strange-bit. Replace the frame with the concrete claim.",
+        "range": [
+          50633,
+          50677
+        ],
+        "ruleId": "generic-signposting",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 100,
+        "index": 50678,
+        "line": 1107,
+        "loc": {
+          "end": {
+            "column": 158,
+            "line": 1107
+          },
+          "start": {
+            "column": 100,
+            "line": 1107
+          }
+        },
+        "message": "Generic signposting found: deictic-evaluative-this-surprising-detail. Replace the frame with the concrete claim.",
+        "range": [
+          50678,
+          50736
+        ],
+        "ruleId": "generic-signposting",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 159,
+        "index": 50737,
+        "line": 1107,
+        "loc": {
+          "end": {
+            "column": 222,
+            "line": 1107
+          },
+          "start": {
+            "column": 159,
+            "line": 1107
+          }
+        },
+        "message": "Generic signposting found: deictic-evaluative-this-useful-point. Replace the frame with the concrete claim.",
+        "range": [
+          50737,
+          50800
+        ],
+        "ruleId": "generic-signposting",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 69,
+        "index": 50870,
+        "line": 1109,
+        "loc": {
+          "end": {
+            "column": 130,
+            "line": 1109
+          },
+          "start": {
+            "column": 69,
+            "line": 1109
+          }
+        },
+        "message": "Generic signposting found: deictic-evaluative-that-tricky-aspect. Replace the frame with the concrete claim.",
+        "range": [
+          50870,
+          50931
+        ],
+        "ruleId": "generic-signposting",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 131,
+        "index": 50932,
+        "line": 1109,
+        "loc": {
+          "end": {
+            "column": 156,
+            "line": 1109
+          },
+          "start": {
+            "column": 131,
+            "line": 1109
+          }
+        },
+        "message": "Generic signposting found: deictic-evaluative-that-funny-twist. Replace the frame with the concrete claim.",
+        "range": [
+          50932,
+          50957
+        ],
+        "ruleId": "generic-signposting",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 69,
+        "index": 51027,
+        "line": 1111,
+        "loc": {
+          "end": {
+            "column": 89,
+            "line": 1111
+          },
+          "start": {
+            "column": 69,
+            "line": 1111
+          }
+        },
+        "message": "Generic signposting found: deictic-evaluative-here-great-idea. Replace the frame with the concrete claim.",
+        "range": [
+          51027,
+          51047
+        ],
+        "ruleId": "generic-signposting",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 90,
+        "index": 51048,
+        "line": 1111,
+        "loc": {
+          "end": {
+            "column": 114,
+            "line": 1111
+          },
+          "start": {
+            "column": 90,
+            "line": 1111
+          }
+        },
+        "message": "Generic signposting found: deictic-evaluative-this-key-element. Replace the frame with the concrete claim.",
+        "range": [
+          51048,
+          51072
+        ],
+        "ruleId": "generic-signposting",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 115,
+        "index": 51073,
+        "line": 1111,
+        "loc": {
+          "end": {
+            "column": 142,
+            "line": 1111
+          },
+          "start": {
+            "column": 115,
+            "line": 1111
+          }
+        },
+        "message": "Generic signposting found: deictic-evaluative-that-remarkable-piece. Replace the frame with the concrete claim.",
+        "range": [
+          51073,
+          51100
+        ],
+        "ruleId": "generic-signposting",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 66,
+        "index": 51167,
+        "line": 1113,
+        "loc": {
+          "end": {
+            "column": 96,
+            "line": 1113
+          },
+          "start": {
+            "column": 66,
+            "line": 1113
+          }
+        },
+        "message": "Generic signposting found: deictic-evaluative-here-interesting-angle. Replace the frame with the concrete claim.",
+        "range": [
+          51167,
+          51197
+        ],
+        "ruleId": "generic-signposting",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 97,
+        "index": 51198,
+        "line": 1113,
+        "loc": {
+          "end": {
+            "column": 123,
+            "line": 1113
+          },
+          "start": {
+            "column": 97,
+            "line": 1113
+          }
+        },
+        "message": "Generic signposting found: deictic-evaluative-this-obvious-catch. Replace the frame with the concrete claim.",
+        "range": [
+          51198,
+          51224
+        ],
+        "ruleId": "generic-signposting",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 124,
+        "index": 51225,
+        "line": 1113,
+        "loc": {
+          "end": {
+            "column": 152,
+            "line": 1113
+          },
+          "start": {
+            "column": 124,
+            "line": 1113
+          }
+        },
+        "message": "Generic signposting found: deictic-evaluative-here-important-aspect. Replace the frame with the concrete claim.",
+        "range": [
+          51225,
+          51253
+        ],
+        "ruleId": "generic-signposting",
         "severity": 2,
         "type": "lint"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "slopless",
-  "version": "0.2.26",
+  "version": "0.2.27",
   "description": "Deterministic textlint rules and CLI for catching prose slop in English Markdown.",
   "keywords": [
     "textlint",

--- a/scripts/behavior-replay.sh
+++ b/scripts/behavior-replay.sh
@@ -4,10 +4,13 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 TEXTLINT="$ROOT/node_modules/.bin/textlint"
 
-cd "$ROOT"
-pnpm run build >/dev/null
+mkdir -p "$ROOT/.fixture3"
+TMP_DIR="$(mktemp -d "$ROOT/.fixture3/replay.XXXXXX")"
+trap 'rm -rf "$TMP_DIR"' EXIT
+RULES_ROOT="$TMP_DIR/dist/rules"
 
 cd "$ROOT"
+"$ROOT/node_modules/.bin/tsc" -p tsconfig.json --outDir "$TMP_DIR/dist"
 
 if [ "$#" -eq 0 ]; then
   mapfile -t FILES < <(find behavior/fixtures/textlint-rules/cases behavior/fixtures/textlint-rules/corpus -name "*.md" | sort)
@@ -17,21 +20,21 @@ fi
 
 CONFIG_ARGS=(--no-textlintrc)
 RULE_ARGS=(
-  --rulesdir "$ROOT/dist/rules/academic-slop"
-  --rulesdir "$ROOT/dist/rules/metrics"
-  --rulesdir "$ROOT/dist/rules/narrative-slop"
-  --rulesdir "$ROOT/dist/rules/orthography"
-  --rulesdir "$ROOT/dist/rules/words"
-  --rulesdir "$ROOT/dist/rules/phrases"
-  --rulesdir "$ROOT/dist/rules/semantic-thinness"
-  --rulesdir "$ROOT/dist/rules/term-policy"
-  --rulesdir "$ROOT/dist/rules/syntactic-patterns/authority"
-  --rulesdir "$ROOT/dist/rules/syntactic-patterns/closers"
-  --rulesdir "$ROOT/dist/rules/syntactic-patterns/contrast"
-  --rulesdir "$ROOT/dist/rules/syntactic-patterns/generalization"
-  --rulesdir "$ROOT/dist/rules/syntactic-patterns/lead-ins"
-  --rulesdir "$ROOT/dist/rules/syntactic-patterns/llm-artifacts"
-  --rulesdir "$ROOT/dist/rules/syntactic-patterns/repetition"
+  --rulesdir "$RULES_ROOT/academic-slop"
+  --rulesdir "$RULES_ROOT/metrics"
+  --rulesdir "$RULES_ROOT/narrative-slop"
+  --rulesdir "$RULES_ROOT/orthography"
+  --rulesdir "$RULES_ROOT/words"
+  --rulesdir "$RULES_ROOT/phrases"
+  --rulesdir "$RULES_ROOT/semantic-thinness"
+  --rulesdir "$RULES_ROOT/term-policy"
+  --rulesdir "$RULES_ROOT/syntactic-patterns/authority"
+  --rulesdir "$RULES_ROOT/syntactic-patterns/closers"
+  --rulesdir "$RULES_ROOT/syntactic-patterns/contrast"
+  --rulesdir "$RULES_ROOT/syntactic-patterns/generalization"
+  --rulesdir "$RULES_ROOT/syntactic-patterns/lead-ins"
+  --rulesdir "$RULES_ROOT/syntactic-patterns/llm-artifacts"
+  --rulesdir "$RULES_ROOT/syntactic-patterns/repetition"
 )
 run_textlint_json() {
   local output="$1"
@@ -47,9 +50,6 @@ run_textlint_json() {
     return "$status"
   fi
 }
-
-TMP_DIR="$(mktemp -d)"
-trap 'rm -rf "$TMP_DIR"' EXIT
 
 JSON_OUTPUTS=()
 DEFAULT_OUTPUT="$TMP_DIR/default.json"
@@ -71,7 +71,7 @@ for FILE in "${FILES[@]}"; do
     run_textlint_json \
       "$CONFIG_OUTPUT" \
       --config "$FIXTURE_CONFIG" \
-      --rules-base-directory "$ROOT/dist/rules/$FAMILY" \
+      --rules-base-directory "$RULES_ROOT/$FAMILY" \
       "$FILE"
     JSON_OUTPUTS+=("$CONFIG_OUTPUT")
   fi
@@ -88,7 +88,7 @@ for FILE in "${FILES[@]}"; do
     run_textlint_json \
       "$CONFIG_OUTPUT" \
       --config "$FIXTURE_CONFIG" \
-      --rules-base-directory "$ROOT/dist/rules/$FAMILY" \
+      --rules-base-directory "$RULES_ROOT/$FAMILY" \
       "$FILE"
     JSON_OUTPUTS+=("$CONFIG_OUTPUT")
   done

--- a/src/rules/syntactic-patterns/lead-ins/generic-signposting.ts
+++ b/src/rules/syntactic-patterns/lead-ins/generic-signposting.ts
@@ -195,7 +195,7 @@ function matchAbstractFrame(text: string): string | undefined {
   const words = tokens(text);
   return (
     matchRelativeDiscourseFrame(text, words) ??
-    matchExpandedDiscourseFrame(words) ??
+    matchExpandedDiscourseFrame(text, words) ??
     matchModifiedAbstractFrame(words) ??
     matchDiscourseEvaluationFrame(words) ??
     matchPointIsToFrame(words) ??
@@ -281,6 +281,7 @@ function matchSignposting(sentence: string): SentenceMatch | undefined {
   if (
     abstract !== undefined &&
     (abstract === "what-matters-is" ||
+      abstract.startsWith("deictic-evaluative-") ||
       abstract.startsWith("relative-") ||
       !concreteImplementation)
   ) {

--- a/src/rules/syntactic-patterns/lead-ins/private/discourse-evaluation.ts
+++ b/src/rules/syntactic-patterns/lead-ins/private/discourse-evaluation.ts
@@ -6,6 +6,53 @@ const DISCOURSE_WORK_TAILS = [
   ["load", "bearing"]
 ] as const;
 const DETERMINERS = new Set(["a", "an", "the", "this", "that"]);
+const DEICTIC_OPENERS = new Set(["here", "this", "that"]);
+const DEICTIC_CONTRACTIONS = new Map([
+  ["here's", "here"],
+  ["this's", "this"],
+  ["that's", "that"]
+]);
+const DEICTIC_EVALUATIVE_ADJECTIVES = new Set([
+  "best",
+  "better",
+  "biggest",
+  "central",
+  "core",
+  "crucial",
+  "funny",
+  "good",
+  "great",
+  "hard",
+  "important",
+  "interesting",
+  "key",
+  "main",
+  "neat",
+  "nice",
+  "odd",
+  "obvious",
+  "remarkable",
+  "strange",
+  "surprising",
+  "tricky",
+  "useful",
+  "weird",
+  "wild"
+]);
+const DEICTIC_DISCOURSE_NOUNS = new Set([
+  "angle",
+  "aspect",
+  "bit",
+  "catch",
+  "detail",
+  "element",
+  "idea",
+  "part",
+  "piece",
+  "point",
+  "thing",
+  "twist"
+]);
 const FRAME_ADJECTIVES = new Set([
   "basic",
   "best",
@@ -233,6 +280,47 @@ function matchEvaluativeFrame(words: readonly string[]): string | undefined {
     : undefined;
 }
 
+function matchDeicticEvaluativeFrame(
+  text: string,
+  words: readonly string[]
+): string | undefined {
+  const contractedOpener = DEICTIC_CONTRACTIONS.get(words[0] ?? "");
+  const opener = contractedOpener ?? words[0];
+  const determinerIndex = contractedOpener === undefined ? 2 : 1;
+
+  if (
+    opener === undefined ||
+    !DEICTIC_OPENERS.has(opener) ||
+    (contractedOpener === undefined &&
+      !["is", "was"].includes(words[1] ?? "")) ||
+    !["a", "an", "the"].includes(words[determinerIndex] ?? "")
+  ) {
+    return undefined;
+  }
+
+  const adjective = words[determinerIndex + 1];
+  const noun = words[determinerIndex + 2];
+  const frame =
+    adjective !== undefined && noun !== undefined
+      ? words.slice(0, determinerIndex + 3).join(" ")
+      : undefined;
+  const boundary = frame === undefined ? undefined : text.at(frame.length);
+
+  return adjective !== undefined &&
+    noun !== undefined &&
+    (boundary === undefined ||
+      boundary === "." ||
+      boundary === "!" ||
+      boundary === "?" ||
+      boundary === ":" ||
+      boundary === ";" ||
+      boundary === ",") &&
+    DEICTIC_EVALUATIVE_ADJECTIVES.has(adjective) &&
+    DEICTIC_DISCOURSE_NOUNS.has(noun)
+    ? `deictic-evaluative-${opener}-${adjective}-${noun}`
+    : undefined;
+}
+
 export function isAbstractAuditFrame(words: readonly string[]): boolean {
   return words[0] === "the" && frameNounIndex(words) > 0
     ? words[frameNounIndex(words)] === "audit"
@@ -240,9 +328,11 @@ export function isAbstractAuditFrame(words: readonly string[]): boolean {
 }
 
 export function matchExpandedDiscourseFrame(
+  text: string,
   words: readonly string[]
 ): string | undefined {
   return (
+    matchDeicticEvaluativeFrame(text, words) ??
     matchWorthAttentionFrame(words) ??
     matchVagueFrameLocation(words) ??
     matchEvaluativeFrame(words)


### PR DESCRIPTION
## Summary
- generalize generic signposting across opener, adjective, and discourse-noun slots
- preserve concrete noun-phrase continuations as no-hits
- isolate Fixture3 suite builds to remove parallel `dist/` races

## Verification
- `pnpm validate`
- `specular lint .plans/2026-07-24-142849-deictic-evaluative-signposting.md.spec.json`
- `specular verify .plans/2026-07-24-142849-deictic-evaluative-signposting.md.spec.json`
- `fixture3 doctor`
- `fixture3 check --all`
- adversarial review completed and blocker resolved