### PR TITLE
Detect vague change framing and quietly overuse

### DIFF
--- a/.plans/2026-07-24-191446-vague-change-and-quietly-density.md
+++ b/.plans/2026-07-24-191446-vague-change-and-quietly-density.md
@@ -1,0 +1,144 @@
+# Goal
+
+Catch vague AI-style change framing built from words such as `shift` and
+`quietly` without banning ordinary physical, scheduled, measured, or
+specifically explained uses.
+
+The completed behavior must:
+
+- report strong vague-change frames once through the existing
+  `semantic-thinness` rule;
+- report repeated standalone `quietly` through a new word-density rule;
+- keep one to three standalone `quietly` uses silent;
+- keep concrete changes that name an actor, object, date, measurement,
+  direction, cause, or before-and-after state silent;
+- preserve every existing public rule behavior.
+
+# Approach
+
+1. Extend the existing `something-shifted` semantic-thinness pattern instead
+   of creating another semantic rule. Add full-sentence templates for:
+   - diffuse subjects plus weak manner adverbs and change verbs;
+   - deictic subjects plus weak manner adverbs and empty change objects;
+   - evaluative `shift` noun phrases with empty predicates;
+   - `marks`, `signals`, `represents`, and `reflects` followed by an
+     evaluative `shift` noun phrase.
+   Use the generic pattern compiler's existing per-template match-mode
+   override. Keep the five existing `something-shifted` templates in
+   `contains` mode and apply `full` only to the new vague-change frames.
+2. Use explicit slots:
+   - diffuse subjects: `the market`, `the industry`, `search`, `the web`,
+     `the landscape`, `the platform`, `the system`, `the process`,
+     `the conversation`, `the work`, `the strategy`, `the model`,
+     `the product`, `the category`, and `the space`;
+   - weak manner adverbs: `quietly`, `silently`, `subtly`, `gradually`,
+     `steadily`, `almost invisibly`, and `under the surface`;
+   - separate finite, past, and progressive change forms so auxiliaries cannot
+     combine with grammatically incompatible verbs;
+   - shift modifiers: `quiet`, `subtle`, `broader`, `meaningful`,
+     `important`, `major`, `fundamental`, `seismic`, `structural`,
+     `profound`, `significant`, and `notable`;
+   - empty shift predicates: `is underway`, `is happening`, `has begun`,
+     `is already here`, `is easy to miss`, `is hard to ignore`, `matters`,
+     and `changes everything`.
+3. Keep the semantic templates in full-match mode. An informative continuation
+   therefore prevents the match:
+   - `from Monday to Thursday`;
+   - `from keyword matching to vector retrieval`;
+   - `3 points after the announcement`;
+   - a concrete direct object or named result.
+4. Extract the existing token density construction from
+   `actually-overuse.ts` into a private words-family builder. Preserve the
+   existing `actually-overuse` rule ID, thresholds, message, and behavior.
+5. Add `words:quietly-overuse` using that builder:
+   - count exact `quietly` tokens over the document;
+   - require at least four occurrences;
+   - warn above one occurrence per 1,000 words;
+   - error above two occurrences per 1,000 words;
+   - report at the first occurrence with count and rate in the message.
+6. Register `quietly-overuse` in the words registry, the everything preset,
+   and the package export map.
+7. Fix `documentUnit()` to derive its existing paragraph-only text and source
+   offsets from one mapped representation. Map each condensed paragraph
+   through textlint's `StringSource` and its absolute node offset. Normalize
+   Markdown hard breaks to one mapped space before extracting paragraph text,
+   keep image alt text excluded from document prose, and preserve inline HTML
+   text exactly as the prior document extractor did. The text used for
+   detection and the text used for source mapping therefore remain
+   position-compatible without duplicating captions or changing density
+   inputs. This keeps findings attached to the first matched source token after
+   headings, earlier paragraphs, and hard breaks.
+8. Add public behavior fixtures:
+   - semantic-thinness hit cases for every template shape and representative
+     slot combinations;
+   - semantic-thinness no-hit cases for physical movement, schedules,
+     measurements, named changes, dates, causes, and literal quiet action;
+   - a words fixture that produces an error for repeated `quietly`;
+   - words no-hit cases with one and three ordinary `quietly` uses;
+   - rate-boundary documents proving warning severity and silence at exactly
+     one occurrence per 1,000 words;
+   - a Markdown document with headings and prior paragraphs proving the
+     reported location maps to the first `quietly` token;
+   - a Markdown hard-break document proving a token after the break maps to
+     the complete source token.
+9. Embed the semantic and word cases in readable corpus prose and update the
+   corresponding preserve files. The corpus may add findings, but it must
+   retain every finding represented by the case fixtures.
+10. Run targeted changed-rule audits over the local human, suspected-AI, and
+   generated-AI corpora. Review every human semantic-template hit and every
+   human document reported by `quietly-overuse`. Tighten the structural
+   boundary when a finding is informative rather than filler.
+11. Review Fixture3 diffs before approval. Run all Fixture3 suites, repository
+    validation, Specular verification, and one adversarial review.
+12. Bump the package to `0.2.28`, merge through a pull request after CI passes,
+    publish the GitHub release to npm, install `slopless@0.2.28` globally, and
+    smoke-test the installed CLI.
+
+# Key Decisions
+
+- `shift` and `quietly` remain valid words. Neither is prohibited.
+- Strong composite frames report once because the whole sentence is the
+  problem.
+- Standalone `quietly` reports only after repetition because literal manner is
+  common.
+- Density remains per document and per 1,000 words. Four occurrences are the
+  minimum evidence for standalone overuse; one to three occurrences never
+  report, even in a short document.
+- Full-sentence semantic templates provide the concrete-information boundary.
+  A trailing specification changes the sentence from an empty announcement
+  into a named change.
+- Per-template match mode belongs in the generic pattern compiler because a
+  single conceptual pattern can contain both embedded legacy frames and new
+  sentence-complete frames. Splitting the behavior into another pattern file
+  would duplicate ownership.
+- The density builder is private to the words family. It removes duplication
+  between `actually-overuse` and `quietly-overuse` without changing the
+  reporting layer or public rule contracts.
+
+# Files To Modify
+
+- `src/rules/semantic-thinness/patterns/something-shifted.json`
+- `src/adapters/textlint/units.ts`
+- `src/shared/text/document.ts`
+- `src/shared/text/sections.ts`
+- `src/shared/text/traverse.ts`
+- `src/rules/words/private/token-density-rule.ts`
+- `src/rules/words/actually-overuse.ts`
+- `src/rules/words/quietly-overuse.ts`
+- `src/registries/words.ts`
+- `src/presets/everything.ts`
+- `package.json`
+- `behavior/fixtures/textlint-rules/cases/semantic-thinness/hits.md`
+- `behavior/fixtures/textlint-rules/cases/semantic-thinness/no-hits.md`
+- `behavior/fixtures/textlint-rules/cases/words/quietly-below-minimum.md`
+- `behavior/fixtures/textlint-rules/cases/words/quietly-overuse.md`
+- `behavior/fixtures/textlint-rules/cases/words/quietly-warning-rate.md`
+- `behavior/fixtures/textlint-rules/cases/words/quietly-at-rate-boundary.md`
+- `behavior/fixtures/textlint-rules/cases/words/quietly-hard-break.md`
+- `behavior/fixtures/textlint-rules/cases/words/no-hits.md`
+- `behavior/fixtures/textlint-rules/corpus/engineering-review.md`
+- `behavior/fixtures/textlint-rules/corpus/engineering-review.preserve.json`
+- `behavior/fixtures/textlint-rules/corpus/editorial-style.md`
+- `behavior/fixtures/textlint-rules/corpus/editorial-style.preserve.json`
+- reviewed Fixture3 approved outputs for changed suites
+- this plan, its Specular specification and coverage map, and the worklog

--- a/.plans/2026-07-24-191446-vague-change-and-quietly-density.md.spec.coverage.md
+++ b/.plans/2026-07-24-191446-vague-change-and-quietly-density.md.spec.coverage.md
@@ -1,0 +1,50 @@
+# Coverage Map
+
+## Goal
+
+- Existing semantic rule ownership and new public word rule:
+  `requirements.tree`, `requirements.content[0]`,
+  `requirements.content[8]`, and `requirements.exports[0]`
+- Strong-frame findings, standalone density behavior, concrete controls, and
+  existing-rule preservation: Fixture3 suites
+  `textlint-rules-cases-semantic-thinness`,
+  `textlint-rules-cases-words`,
+  `textlint-rules-corpus-engineering-review`, and
+  `textlint-rules-corpus-editorial-style`
+
+## Approach
+
+- Steps 1-3: `requirements.content[0]`, `requirements.content[1]`, and
+  semantic-thinness Fixture3 cases
+- Steps 4-5: `requirements.content[6]` through
+  `requirements.content[8]` and words Fixture3 cases
+- Step 6: `requirements.content[9]`, `requirements.content[10]`, and
+  `requirements.exports[0]`
+- Steps 7-9: `requirements.content[2]` through `requirements.content[5]`,
+  `requirements.tree`, and the four named Fixture3 suites
+- Step 10: targeted human, suspected-AI, and generated-AI audit output recorded
+  in the worklog
+- Step 11: Specular output, all Fixture3 suites, repository validation, and
+  adversarial review output
+- Step 12: `requirements.content[11]`; pull request, CI, GitHub release, npm
+  publication, global installation, and installed CLI probe are external
+  verification
+
+## Key Decisions
+
+- Valid standalone words and full-frame semantic boundary: semantic-thinness
+  hit/no-hit Fixture3 cases
+- Repetition-only standalone `quietly`, including three-use silence: words
+  Fixture3 cases
+- Per-document rate and minimum occurrence policy:
+  `requirements.content[6]` and `requirements.content[8]`
+- Private builder ownership: `requirements.exports[0]`
+- Document source-offset mapping: `requirements.content[2]` through
+  `requirements.content[5]`
+
+## Files To Modify
+
+- Required implementation, fixture, corpus, and approved behavior paths:
+  `requirements.tree`
+- Required source contents: `requirements.content`
+- Public and private package boundaries: `requirements.exports[0]`

--- a/.plans/2026-07-24-191446-vague-change-and-quietly-density.md.spec.json
+++ b/.plans/2026-07-24-191446-vague-change-and-quietly-density.md.spec.json
@@ -1,0 +1,252 @@
+{
+  "version": 4,
+  "requirements": {
+    "tree": {
+      "verifier": ["builtin:tree"],
+      "reason": "Unanimous extraction: implementation, fixture, corpus, and approved behavior files",
+      "required": [
+        "src/rules/semantic-thinness/patterns/something-shifted.json",
+        "src/rules/semantic-thinness/private/pattern-matcher.ts",
+        "src/adapters/textlint/units.ts",
+        "src/shared/text/document.ts",
+        "src/shared/text/sections.ts",
+        "src/shared/text/traverse.ts",
+        "src/rules/words/private/token-density-rule.ts",
+        "src/rules/words/actually-overuse.ts",
+        "src/rules/words/quietly-overuse.ts",
+        "src/registries/words.ts",
+        "src/presets/everything.ts",
+        "package.json",
+        "behavior/fixtures/textlint-rules/cases/semantic-thinness/hits.md",
+        "behavior/fixtures/textlint-rules/cases/semantic-thinness/no-hits.md",
+        "behavior/fixtures/textlint-rules/cases/words/quietly-below-minimum.md",
+        "behavior/fixtures/textlint-rules/cases/words/quietly-overuse.md",
+        "behavior/fixtures/textlint-rules/cases/words/quietly-warning-rate.md",
+        "behavior/fixtures/textlint-rules/cases/words/quietly-at-rate-boundary.md",
+        "behavior/fixtures/textlint-rules/cases/words/quietly-hard-break.md",
+        "behavior/fixtures/textlint-rules/cases/words/no-hits.md",
+        "behavior/fixtures/textlint-rules/corpus/engineering-review.md",
+        "behavior/fixtures/textlint-rules/corpus/engineering-review.preserve.json",
+        "behavior/fixtures/textlint-rules/corpus/editorial-style.md",
+        "behavior/fixtures/textlint-rules/corpus/editorial-style.preserve.json",
+        "behavior/golden/textlint-rules-cases-semantic-thinness/approved.normalized.json",
+        "behavior/golden/textlint-rules-cases-words/approved.normalized.json",
+        "behavior/golden/textlint-rules-cases-orthography/approved.normalized.json",
+        "behavior/golden/textlint-rules-corpus-engineering-review/approved.normalized.json",
+        "behavior/golden/textlint-rules-corpus-editorial-style/approved.normalized.json",
+        "behavior/golden/textlint-rules-corpus-health-and-parenting/approved.normalized.json",
+        "behavior/golden/textlint-rules-corpus-linkedin-ai-search/approved.normalized.json",
+        "behavior/golden/textlint-rules-corpus-metrics-and-markdown/approved.normalized.json",
+        "behavior/golden/textlint-rules-corpus-narrative-scenes/approved.normalized.json",
+        "behavior/golden/textlint-rules-corpus-technical-terminology/approved.normalized.json"
+      ]
+    },
+    "content": [
+      {
+        "verifier": ["builtin:content"],
+        "files": [
+          "src/rules/semantic-thinness/patterns/something-shifted.json"
+        ],
+        "reason": "Approach 1-3: extend the existing full-match pattern with the declared slot inventories",
+        "required": [
+          "\"id\": \"something-shifted\"",
+          "\"matchMode\": \"full\"",
+          "\"diffuseSubject\"",
+          "\"weakMannerAdverb\"",
+          "\"finiteChange\"",
+          "\"pastChange\"",
+          "\"progressiveChange\"",
+          "\"progressiveAuxiliary\"",
+          "\"perfectAuxiliary\"",
+          "\"shiftModifier\"",
+          "\"emptyShiftPredicate\"",
+          "\"the market\"",
+          "\"the industry\"",
+          "\"search\"",
+          "\"the web\"",
+          "\"the landscape\"",
+          "\"the platform\"",
+          "\"the system\"",
+          "\"the process\"",
+          "\"the conversation\"",
+          "\"the work\"",
+          "\"the strategy\"",
+          "\"the model\"",
+          "\"the product\"",
+          "\"the category\"",
+          "\"the space\"",
+          "\"quietly\"",
+          "\"silently\"",
+          "\"subtly\"",
+          "\"gradually\"",
+          "\"steadily\"",
+          "\"almost invisibly\"",
+          "\"under the surface\"",
+          "\"changes\"",
+          "\"shifts\"",
+          "\"evolves\"",
+          "\"transforms\"",
+          "\"reshapes\"",
+          "\"redefines\"",
+          "\"moves\"",
+          "\"changing\"",
+          "\"shifting\"",
+          "\"evolving\"",
+          "\"transforming\"",
+          "\"reshaping\"",
+          "\"redefining\"",
+          "\"moving\"",
+          "\"quiet\"",
+          "\"subtle\"",
+          "\"broader\"",
+          "\"meaningful\"",
+          "\"important\"",
+          "\"major\"",
+          "\"fundamental\"",
+          "\"seismic\"",
+          "\"structural\"",
+          "\"profound\"",
+          "\"significant\"",
+          "\"notable\"",
+          "\"is underway\"",
+          "\"is happening\"",
+          "\"has begun\"",
+          "\"is already here\"",
+          "\"is easy to miss\"",
+          "\"is hard to ignore\"",
+          "\"matters\"",
+          "\"changes everything\""
+        ]
+      },
+      {
+        "verifier": ["builtin:content"],
+        "files": ["src/rules/semantic-thinness/private/pattern-matcher.ts"],
+        "reason": "Approach 1: allow typed per-template match-mode overrides while preserving string templates",
+        "required": [
+          "readonly text: string",
+          "readonly matchMode",
+          "template.matchMode === \"contains\"",
+          "template.matchMode === \"connector\"",
+          "template.matchMode === \"full\"",
+          "template.matchMode === \"suffix\""
+        ]
+      },
+      {
+        "verifier": ["builtin:content"],
+        "files": ["src/adapters/textlint/units.ts"],
+        "reason": "Approach 7: map document-level detections through textlint source offsets",
+        "required": [
+          "const source = documentSourceText(document)",
+          "source.originalStartFor(range.start)",
+          "source.originalEndFor(range.end)"
+        ]
+      },
+      {
+        "verifier": ["builtin:content"],
+        "files": ["src/shared/text/document.ts"],
+        "reason": "Approach 7: preserve paragraph-only document text while mapping it to Markdown source",
+        "required": [
+          "documentSourceText",
+          "originalOffsetFor",
+          "paragraph.source.originalStartFor",
+          "paragraph.source.originalEndFor"
+        ]
+      },
+      {
+        "verifier": ["builtin:content"],
+        "files": ["src/shared/text/sections.ts"],
+        "reason": "Approach 7: derive paragraph text and source positions from one representation",
+        "required": [
+          "const source = proseSourceText(paragraph)",
+          "text: source.text"
+        ]
+      },
+      {
+        "verifier": ["builtin:content"],
+        "files": ["src/shared/text/traverse.ts"],
+        "reason": "Approach 7: preserve a mapped separator for Markdown hard breaks",
+        "required": [
+          "normalizeNode",
+          "node.type === \"Break\"",
+          "value: \" \"",
+          "proseSourceText",
+          "node.type === \"Image\"",
+          "node.type === \"ImageReference\"",
+          "node.type === \"Html\""
+        ]
+      },
+      {
+        "verifier": ["builtin:content"],
+        "files": ["src/rules/words/private/token-density-rule.ts"],
+        "reason": "Approach 4-5: private exact-token document-density construction",
+        "required": [
+          "defineTextlintRule",
+          "documentUnit",
+          "wordTokens",
+          "minimumOccurrences",
+          "warningPerUnit",
+          "errorPerUnit",
+          "wordsPerUnit"
+        ]
+      },
+      {
+        "verifier": ["builtin:content"],
+        "files": ["src/rules/words/actually-overuse.ts"],
+        "reason": "Approach 4: preserve actually-overuse through the private builder",
+        "required": [
+          "./private/token-density-rule.js",
+          "\"actually\"",
+          "\"words:actually-overuse\""
+        ]
+      },
+      {
+        "verifier": ["builtin:content"],
+        "files": ["src/rules/words/quietly-overuse.ts"],
+        "reason": "Approach 5: configure quietly density and its public identity",
+        "required": [
+          "./private/token-density-rule.js",
+          "\"quietly\"",
+          "\"words:quietly-overuse\"",
+          "minimumOccurrences: 4",
+          "warningPerUnit: 1",
+          "errorPerUnit: 2",
+          "wordsPerUnit: 1000"
+        ]
+      },
+      {
+        "verifier": ["builtin:content"],
+        "files": ["src/registries/words.ts"],
+        "reason": "Approach 6: register quietly-overuse",
+        "required": [
+          "../rules/words/quietly-overuse.js",
+          "\"quietly-overuse\": quietlyOveruse"
+        ]
+      },
+      {
+        "verifier": ["builtin:content"],
+        "files": ["src/presets/everything.ts"],
+        "reason": "Approach 6: enable quietly-overuse",
+        "required": ["\"quietly-overuse\": true"]
+      },
+      {
+        "verifier": ["builtin:content"],
+        "files": ["package.json"],
+        "reason": "Approach 11: patch release version",
+        "required": ["\"version\": \"0.2.28\""],
+        "forbidden": ["\"version\": \"0.2.27\""]
+      }
+    ],
+    "exports": [
+      {
+        "verifier": [
+          "node",
+          ".plans/2026-07-21-190541-relative-signposting-and-evidence-limitation.md.spec.verify.mjs"
+        ],
+        "package": "slopless",
+        "reason": "Approach 6: expose the rule and keep its builder private",
+        "required": ["./rules/words/quietly-overuse"],
+        "forbidden": ["./rules/words/private/token-density-rule"]
+      }
+    ]
+  }
+}

--- a/.worklogs/2026-07-24-195203-vague-change-and-quietly-density.md
+++ b/.worklogs/2026-07-24-195203-vague-change-and-quietly-density.md
@@ -1,0 +1,106 @@
+# Summary
+
+Expanded the existing `something-shifted` semantic pattern with grammatical
+full-sentence vague-change templates and added a public
+`words:quietly-overuse` document-density rule. Added isolated hit, no-hit,
+warning, and rate-boundary fixtures; corpus parity; reviewed golden outputs;
+correct source-offset mapping; and package version `0.2.28`.
+
+# Decisions Made
+
+- Kept vague change under the existing semantic-thinness rule and pattern ID
+  instead of adding another family or rule.
+- Used the existing per-template match-mode override so the five older embedded
+  `something-shifted` templates retain `contains` behavior while new templates
+  require full-sentence matches.
+- Split finite, progressive, and past change forms so auxiliaries cannot
+  produce or require mismatched verb forms.
+- Kept `quietly` legal and counted exact tokens over the document at warning
+  above 1 per 1,000 words and error above 2 per 1,000 words.
+- Raised the minimum evidence from 2 to 4 occurrences after the first human
+  corpus audit found 7 false positives: 6 literary excerpts with 2 ordinary
+  uses and 1 article with 3 proper-name uses. Rechecking those documents
+  produced no findings; one AI-suspected document with 4 generic filler uses
+  still produced an error.
+- Refactored `actually-overuse` through the same private exact-token density
+  builder without changing its public behavior.
+- Kept the existing paragraph-only document text used by density policies, but
+  mapped each report through its paragraph's Markdown source offset. This fixes
+  document-level findings that previously pointed to condensed-text offsets.
+- Normalized Markdown hard breaks to one mapped space in the shared source-text
+  adapter, excluded image alt text from document prose, preserved the prior
+  inline-HTML text, then made paragraph text use that same representation.
+  This fixes tokens after hard breaks without adding a second offset mapper,
+  double-counting image captions, or changing document-density inputs.
+- Preserved all new case text in corpus prose and repaired line references
+  after the semantic case file grew. All 1,730 preserve records resolve to
+  exact source lines and occur in their corpus documents.
+- Corrected one pre-existing stale preserve reference in the copied Arden
+  corpus and two swapped semantic preserve references found by the parity
+  verifier.
+
+# Verification
+
+- `fixture3 doctor`: passed.
+- `fixture3 check --all`: all 19 suites matched.
+- `pnpm run validate`: passed.
+- `specular lint`: passed.
+- `specular verify`: passed with `conforms: true`.
+- New semantic cases include each finite, progressive, perfect, and
+  sentence-final-adverb form. Every intended form hit; all concrete controls
+  with dates, measurements, causes, direct objects, or named transitions
+  remained silent for the new templates.
+- Quietly cases: 3 uses remained silent; 4 uses at about 1.5 per 1,000 words
+  produced a warning; 4 uses in exactly 4,000 words remained silent at the
+  1-per-1,000 boundary; 10 uses produced an error; and the editorial corpus
+  produced an error at 14 uses over about 5,000 words.
+- The first adversarial review found three blockers: grammatically
+  incompatible semantic slot combinations, missing warning/rate-boundary
+  fixtures, and document-density findings reported against condensed offsets.
+  All three were corrected before final approval.
+- Follow-up review found an exact-boundary fixture below 1.0 and a hard-break
+  offset mismatch. The final review confirmed both fixes and reported no code
+  blockers.
+- Targeted corpus audit covered 13,705 human files, 402 AI-generated files,
+  and 1,501 AI-suspected files: 3,452,789 human words, 187,053 generated-AI
+  words, and 1,611,505 suspected-AI words. The new semantic templates produced
+  no external matches. The final 4-occurrence density floor produced no human
+  findings and retained one reviewed AI-suspected article with four generic
+  `quietly` uses. The five human `something-shifted` findings are unchanged
+  legacy-template matches.
+- Reviewed the source-offset Fixture3 drift. New behavior appeared in the
+  semantic, words, engineering-review, and editorial-style suites. All other
+  changed suites retained identical rule IDs, messages, counts, and severities
+  while document-level reports moved from Markdown line 1 to the first source
+  paragraph.
+- Compared the new mapped document text with the prior recursive plain-text
+  extractor across all 35 Markdown behavior fixtures. Every document produced
+  identical density input; only source-range translation changed.
+
+# Key Files For Context
+
+- `.plans/2026-07-24-191446-vague-change-and-quietly-density.md`
+- `src/rules/semantic-thinness/patterns/something-shifted.json`
+- `src/rules/semantic-thinness/private/pattern-matcher.ts`
+- `src/shared/text/document.ts`
+- `src/shared/text/sections.ts`
+- `src/shared/text/traverse.ts`
+- `src/adapters/textlint/units.ts`
+- `src/rules/words/private/token-density-rule.ts`
+- `src/rules/words/quietly-overuse.ts`
+- `behavior/fixtures/textlint-rules/cases/semantic-thinness/hits.md`
+- `behavior/fixtures/textlint-rules/cases/semantic-thinness/no-hits.md`
+- `behavior/fixtures/textlint-rules/cases/words/quietly-overuse.md`
+- `behavior/fixtures/textlint-rules/cases/words/quietly-below-minimum.md`
+- `behavior/fixtures/textlint-rules/cases/words/quietly-warning-rate.md`
+- `behavior/fixtures/textlint-rules/cases/words/quietly-at-rate-boundary.md`
+- `behavior/fixtures/textlint-rules/cases/words/quietly-hard-break.md`
+
+# Next Steps
+
+- Commit and push the feature branch, merge through a pull request after CI
+  passes, publish `v0.2.28`, install `slopless@0.2.28` globally, and run
+  installed-CLI hit/no-hit probes.
+- Track separately that invoking `node dist/cli.js` from an unpacked checkout
+  attempts to resolve `preset-slopless`; the installed CLI remains the
+  supported user surface.

--- a/behavior/fixtures/textlint-rules/cases/semantic-thinness/hits.md
+++ b/behavior/fixtures/textlint-rules/cases/semantic-thinness/hits.md
@@ -266,6 +266,58 @@ The review basically put a number on that.
 
 That's the shift.
 
+The market is quietly shifting.
+
+The industry is subtly evolving.
+
+Search is gradually changing.
+
+The web is silently transforming.
+
+The landscape is steadily reshaping.
+
+The platform is almost invisibly redefining.
+
+This quietly changes everything.
+
+That subtly reshapes everything.
+
+A quiet shift is underway.
+
+The subtle shift is happening.
+
+This broader shift has begun.
+
+A meaningful shift is already here.
+
+The important shift is easy to miss.
+
+The fundamental shift is hard to ignore.
+
+The structural shift matters.
+
+The profound shift changes everything.
+
+This marks a broader shift.
+
+That signals a seismic shift.
+
+This represents a meaningful shift.
+
+This reflects a notable shift.
+
+The platform subtly evolves.
+
+The market quietly shifted.
+
+The web was silently transforming.
+
+The industry has quietly changed.
+
+The model had quietly changed.
+
+The system shifted quietly.
+
 That is the lesson.
 
 This is the honest point.

--- a/behavior/fixtures/textlint-rules/cases/semantic-thinness/no-hits.md
+++ b/behavior/fixtures/textlint-rules/cases/semantic-thinness/no-hits.md
@@ -284,6 +284,50 @@ The feed is the product catalog uploaded to S3.
 
 The report is the answer generated from audit evidence.
 
+The nurse carefully shifted the tray toward the patient.
+
+Please shift slowly so the baby stays asleep.
+
+The agency formally removed rule 14 on July 1.
+
+The transmission shifted smoothly after the mechanic replaced the worn bearing.
+
+The market shifted 3 points after the rate announcement.
+
+The team shifted the launch from Monday to Thursday.
+
+Search is quietly changing from keyword matching to vector retrieval.
+
+The web is gradually moving from HTTP/1.1 to HTTP/2.
+
+The platform is steadily processing 40 events per second.
+
+The system explicitly changed the retry limit from 3 to 5.
+
+A major shift from desktop to mobile cut support calls.
+
+The night shift begins at 22:00.
+
+Press Shift while clicking the second row.
+
+This marks a 4-point shift in the survey.
+
+That reflects the shift from cash to card payments.
+
+The structural shift in tax law took effect on July 1.
+
+The platform subtly evolves after each weekly model update.
+
+The market quietly shifted 3 points after the rate announcement.
+
+The web was silently transforming 40 records per second.
+
+The industry has quietly changed from annual contracts to monthly plans.
+
+The model had quietly changed from version 2 to version 3.
+
+The system shifted quietly after the operator replaced the worn bearing.
+
 That is the point guard selected in the draft.
 
 That is the report prepared for the board.

--- a/behavior/fixtures/textlint-rules/cases/words/no-hits.md
+++ b/behavior/fixtures/textlint-rules/cases/words/no-hits.md
@@ -39,3 +39,5 @@ The AI-native file format stores model metadata in the header.
 The label says the wood finish is authentic shellac.
 
 The city report says the water supply is sustainable under the drought model.
+
+The nurse closed the door quietly so the patient could sleep.

--- a/behavior/fixtures/textlint-rules/cases/words/quietly-at-rate-boundary.md
+++ b/behavior/fixtures/textlint-rules/cases/words/quietly-at-rate-boundary.md
@@ -1,0 +1,387 @@
+# Density policy review
+
+The editor opened the review with a short summary of the publication schedule.
+
+The team then checked the source notes and approved the factual corrections.
+
+## Repeated manner
+
+The editor quietly reviewed the opening section and recorded each concrete change before the team approved the final version for publication.
+
+The analyst quietly checked the source notes and recorded each concrete change before the team approved the final version for publication.
+
+The reviewer quietly examined the closing section and recorded each concrete change before the team approved the final version for publication.
+
+The publisher quietly read the corrected draft and recorded each concrete change before the team approved the final version for publication.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor approved the final draft.

--- a/behavior/fixtures/textlint-rules/cases/words/quietly-below-minimum.md
+++ b/behavior/fixtures/textlint-rules/cases/words/quietly-below-minimum.md
@@ -1,0 +1,1 @@
+Mara closed the nursery door quietly. She read quietly until the child fell asleep. Later, she spoke quietly to the nurse in the hall.

--- a/behavior/fixtures/textlint-rules/cases/words/quietly-hard-break.md
+++ b/behavior/fixtures/textlint-rules/cases/words/quietly-hard-break.md
@@ -1,0 +1,2 @@
+The report began with a measured comparison.\
+The summary quietly changed the subject. The conclusion quietly changed the subject. The sidebar quietly changed the subject. The caption quietly changed the subject.

--- a/behavior/fixtures/textlint-rules/cases/words/quietly-overuse.md
+++ b/behavior/fixtures/textlint-rules/cases/words/quietly-overuse.md
@@ -1,0 +1,3 @@
+The market quietly changed after the launch. The platform quietly moved toward a broader role. The industry quietly shifted around the new model. The strategy quietly evolved during the quarter. The product quietly became the center of the plan.
+
+The process quietly moved in a new direction. The category quietly changed around the new entrant. The conversation quietly shifted toward execution. The work quietly expanded beyond the original brief. The model quietly reshaped the whole market.

--- a/behavior/fixtures/textlint-rules/cases/words/quietly-warning-rate.md
+++ b/behavior/fixtures/textlint-rules/cases/words/quietly-warning-rate.md
@@ -1,0 +1,257 @@
+# Density policy review
+
+The editor opened the review with a short summary of the publication schedule.
+
+The team then checked the source notes and approved the factual corrections.
+
+## Repeated manner
+
+The editor quietly reviewed the opening section and recorded each concrete change before the team approved the final version for publication.
+
+The analyst quietly checked the source notes and recorded each concrete change before the team approved the final version for publication.
+
+The reviewer quietly examined the closing section and recorded each concrete change before the team approved the final version for publication.
+
+The publisher quietly read the corrected draft and recorded each concrete change before the team approved the final version for publication.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.
+
+The editor reviewed the draft and recorded each concrete change before the team approved the final version for publication that afternoon.

--- a/behavior/fixtures/textlint-rules/corpus/arden-chapter-1-polished.preserve.json
+++ b/behavior/fixtures/textlint-rules/corpus/arden-chapter-1-polished.preserve.json
@@ -13,7 +13,7 @@
       "family": "syntactic-patterns",
       "bucket": "hits",
       "source": "cases/syntactic-patterns/hits.md",
-      "line": 1105
+      "line": 1135
     },
     {
       "text": "Everyone went quiet. Silence filled the yard.",

--- a/behavior/fixtures/textlint-rules/corpus/editorial-style.md
+++ b/behavior/fixtures/textlint-rules/corpus/editorial-style.md
@@ -803,3 +803,13 @@ The conclusion announced its reaction before supplying a series of metaphors. He
 The final revision compressed the conclusion again. So the feed is the product now. That's the shift.
 
 The product-selection draft then cycled through modal contractions while preserving the same staged reversal. It can't guess. It reads the product attributes. It couldn't compare pages. It ranked product records. It hasn't checked the source. It reads the summary. It hadn't inspected the listing. It followed the score. They haven't reviewed the pages. They compare the records. It mightn't inspect the page. It reads the feed. It mustn't guess. It checks the evidence. It needn't browse the site. It reads the catalog. It shan't inspect the page. It reads the metadata. It shouldn't guess. It follows the ranking. It won't inspect pages. It reads attributes. It wouldn't inspect pages. It reads product records.
+
+## Manner-adverb review
+
+The editor marked two paragraphs that repeated the same weak manner adverb throughout their claims. The market quietly changed after the launch. The platform quietly moved toward a broader role. The industry quietly shifted around the new model. The strategy quietly evolved during the quarter. The product quietly became the center of the plan.
+
+The repetition continued without adding evidence. The process quietly moved in a new direction. The category quietly changed around the new entrant. The conversation quietly shifted toward execution. The work quietly expanded beyond the original brief. The model quietly reshaped the whole market.
+
+The hospital note used the word once to describe how the nurse protected a sleeping patient. The nurse closed the door quietly so the patient could sleep.
+
+The nursery scene used the word three times for literal volume. Mara closed the nursery door quietly. She read quietly until the child fell asleep. Later, she spoke quietly to the nurse in the hall.

--- a/behavior/fixtures/textlint-rules/corpus/editorial-style.preserve.json
+++ b/behavior/fixtures/textlint-rules/corpus/editorial-style.preserve.json
@@ -2807,105 +2807,105 @@
       "family": "semantic-thinness",
       "bucket": "hits",
       "source": "cases/semantic-thinness/hits.md",
-      "line": 269
+      "line": 321
     },
     {
       "text": "This is the honest point.",
       "family": "semantic-thinness",
       "bucket": "hits",
       "source": "cases/semantic-thinness/hits.md",
-      "line": 271
+      "line": 323
     },
     {
       "text": "It's the missing piece.",
       "family": "semantic-thinness",
       "bucket": "hits",
       "source": "cases/semantic-thinness/hits.md",
-      "line": 273
+      "line": 325
     },
     {
       "text": "To the machine doing the shopping, the feed is the product.",
       "family": "semantic-thinness",
       "bucket": "hits",
       "source": "cases/semantic-thinness/hits.md",
-      "line": 275
+      "line": 327
     },
     {
       "text": "For the search agent, the page is the answer.",
       "family": "semantic-thinness",
       "bucket": "hits",
       "source": "cases/semantic-thinness/hits.md",
-      "line": 277
+      "line": 329
     },
     {
       "text": "To the ranking system, the schema is the storefront.",
       "family": "semantic-thinness",
       "bucket": "hits",
       "source": "cases/semantic-thinness/hits.md",
-      "line": 279
+      "line": 331
     },
     {
       "text": "For the assistant, metadata is the product.",
       "family": "semantic-thinness",
       "bucket": "hits",
       "source": "cases/semantic-thinness/hits.md",
-      "line": 281
+      "line": 333
     },
     {
       "text": "The prompt is the strategy.",
       "family": "semantic-thinness",
       "bucket": "hits",
       "source": "cases/semantic-thinness/hits.md",
-      "line": 283
+      "line": 335
     },
     {
       "text": "The dashboard is the decision.",
       "family": "semantic-thinness",
       "bucket": "hits",
       "source": "cases/semantic-thinness/hits.md",
-      "line": 285
+      "line": 337
     },
     {
       "text": "The report became the answer.",
       "family": "semantic-thinness",
       "bucket": "hits",
       "source": "cases/semantic-thinness/hits.md",
-      "line": 287
+      "line": 339
     },
     {
       "text": "The spreadsheet is the business.",
       "family": "semantic-thinness",
       "bucket": "hits",
       "source": "cases/semantic-thinness/hits.md",
-      "line": 289
+      "line": 341
     },
     {
       "text": "The index is the market.",
       "family": "semantic-thinness",
       "bucket": "hits",
       "source": "cases/semantic-thinness/hits.md",
-      "line": 291
+      "line": 343
     },
     {
       "text": "The pipeline is the work.",
       "family": "semantic-thinness",
       "bucket": "hits",
       "source": "cases/semantic-thinness/hits.md",
-      "line": 293
+      "line": 345
     },
     {
       "text": "The interface is the experience.",
       "family": "semantic-thinness",
       "bucket": "hits",
       "source": "cases/semantic-thinness/hits.md",
-      "line": 295
+      "line": 347
     },
     {
       "text": "The content is the source of truth.",
       "family": "semantic-thinness",
       "bucket": "hits",
       "source": "cases/semantic-thinness/hits.md",
-      "line": 297
+      "line": 349
     },
     {
       "text": "This isn't a data problem. It's a distribution problem.",
@@ -3003,14 +3003,14 @@
       "family": "semantic-thinness",
       "bucket": "hits",
       "source": "cases/semantic-thinness/hits.md",
-      "line": 299
+      "line": 351
     },
     {
       "text": "That's the shift.",
       "family": "semantic-thinness",
       "bucket": "hits",
       "source": "cases/semantic-thinness/hits.md",
-      "line": 301
+      "line": 353
     },
     {
       "text": "It can't guess. It reads the product attributes.",
@@ -3095,6 +3095,34 @@
       "bucket": "hits",
       "source": "cases/syntactic-patterns/hits.md",
       "line": 1469
+    },
+    {
+      "text": "The market quietly changed after the launch. The platform quietly moved toward a broader role. The industry quietly shifted around the new model. The strategy quietly evolved during the quarter. The product quietly became the center of the plan.",
+      "family": "words",
+      "bucket": "hits",
+      "source": "cases/words/quietly-overuse.md",
+      "line": 1
+    },
+    {
+      "text": "The process quietly moved in a new direction. The category quietly changed around the new entrant. The conversation quietly shifted toward execution. The work quietly expanded beyond the original brief. The model quietly reshaped the whole market.",
+      "family": "words",
+      "bucket": "hits",
+      "source": "cases/words/quietly-overuse.md",
+      "line": 3
+    },
+    {
+      "text": "The nurse closed the door quietly so the patient could sleep.",
+      "family": "words",
+      "bucket": "no-hits",
+      "source": "cases/words/no-hits.md",
+      "line": 43
+    },
+    {
+      "text": "Mara closed the nursery door quietly. She read quietly until the child fell asleep. Later, she spoke quietly to the nurse in the hall.",
+      "family": "words",
+      "bucket": "no-hits",
+      "source": "cases/words/quietly-below-minimum.md",
+      "line": 1
     }
   ]
 }

--- a/behavior/fixtures/textlint-rules/corpus/engineering-review.md
+++ b/behavior/fixtures/textlint-rules/corpus/engineering-review.md
@@ -1119,3 +1119,37 @@ The technician continued by naming materials and locations. This is a stainless 
 The last two lines pointed to objects on the bench. There is the best part on the workbench. Here is the largest bearing in the gearbox.
 
 The review closed with four ordinary identifications that reused the allowed adjective and noun slots. Here is the best part of the movie. That is a remarkable piece of Renaissance sculpture. This is the important point on the map. Here is the key element in the periodic table.
+
+## Vague change review
+
+The editor rejected a sequence of announcements that never named the change. The market is quietly shifting. The industry is subtly evolving. Search is gradually changing.
+
+The same draft continued without evidence. The web is silently transforming. The landscape is steadily reshaping. The platform is almost invisibly redefining.
+
+The next draft replaced the subjects with pointers but remained empty. This quietly changes everything. That subtly reshapes everything.
+
+The conclusion repeated the same claim through modified versions of the word shift. A quiet shift is underway. The subtle shift is happening. This broader shift has begun. A meaningful shift is already here.
+
+The modifiers changed but the claim did not. The important shift is easy to miss. The fundamental shift is hard to ignore. The structural shift matters. The profound shift changes everything.
+
+Four final sentences presented the shift as their own evidence. This marks a broader shift. That signals a seismic shift. This represents a meaningful shift. This reflects a notable shift.
+
+The remaining draft varied tense and adverb position without adding a concrete change. The platform subtly evolves. The market quietly shifted. The web was silently transforming.
+
+The last three versions used perfect forms and a trailing adverb. The industry has quietly changed. The model had quietly changed. The system shifted quietly.
+
+## Concrete change controls
+
+The hospital and workshop notes described physical movement. The nurse carefully shifted the tray toward the patient. Please shift slowly so the baby stays asleep. The transmission shifted smoothly after the mechanic replaced the worn bearing.
+
+The policy, market, and launch records named dates, measurements, and destinations. The agency formally removed rule 14 on July 1. The market shifted 3 points after the rate announcement. The team shifted the launch from Monday to Thursday.
+
+The technical summaries named both the change and its boundary. Search is quietly changing from keyword matching to vector retrieval. The web is gradually moving from HTTP/1.1 to HTTP/2. The platform is steadily processing 40 events per second. The system explicitly changed the retry limit from 3 to 5.
+
+The remaining controls used shift as a measured change, a work period, or a keyboard key. A major shift from desktop to mobile cut support calls. The night shift begins at 22:00. Press Shift while clicking the second row.
+
+The final records named the measured transition. This marks a 4-point shift in the survey. That reflects the shift from cash to card payments. The structural shift in tax law took effect on July 1.
+
+The grammatical controls kept the same verb forms but supplied measurements, causes, or before-and-after states. The platform subtly evolves after each weekly model update. The market quietly shifted 3 points after the rate announcement. The web was silently transforming 40 records per second.
+
+The final controls named both endpoints or the physical cause. The industry has quietly changed from annual contracts to monthly plans. The model had quietly changed from version 2 to version 3. The system shifted quietly after the operator replaced the worn bearing.

--- a/behavior/fixtures/textlint-rules/corpus/engineering-review.preserve.json
+++ b/behavior/fixtures/textlint-rules/corpus/engineering-review.preserve.json
@@ -4186,14 +4186,14 @@
       "family": "semantic-thinness",
       "bucket": "no-hits",
       "source": "cases/semantic-thinness/no-hits.md",
-      "line": 287
+      "line": 331
     },
     {
       "text": "That is the report prepared for the board.",
       "family": "semantic-thinness",
       "bucket": "no-hits",
       "source": "cases/semantic-thinness/no-hits.md",
-      "line": 289
+      "line": 333
     },
     {
       "text": "It can't start because the battery voltage is below 11 volts.",
@@ -4523,6 +4523,342 @@
       "bucket": "no-hits",
       "source": "cases/syntactic-patterns/no-hits.md",
       "line": 595
+    },
+    {
+      "text": "The market is quietly shifting.",
+      "family": "semantic-thinness",
+      "bucket": "hits",
+      "source": "cases/semantic-thinness/hits.md",
+      "line": 269
+    },
+    {
+      "text": "The industry is subtly evolving.",
+      "family": "semantic-thinness",
+      "bucket": "hits",
+      "source": "cases/semantic-thinness/hits.md",
+      "line": 271
+    },
+    {
+      "text": "Search is gradually changing.",
+      "family": "semantic-thinness",
+      "bucket": "hits",
+      "source": "cases/semantic-thinness/hits.md",
+      "line": 273
+    },
+    {
+      "text": "The web is silently transforming.",
+      "family": "semantic-thinness",
+      "bucket": "hits",
+      "source": "cases/semantic-thinness/hits.md",
+      "line": 275
+    },
+    {
+      "text": "The landscape is steadily reshaping.",
+      "family": "semantic-thinness",
+      "bucket": "hits",
+      "source": "cases/semantic-thinness/hits.md",
+      "line": 277
+    },
+    {
+      "text": "The platform is almost invisibly redefining.",
+      "family": "semantic-thinness",
+      "bucket": "hits",
+      "source": "cases/semantic-thinness/hits.md",
+      "line": 279
+    },
+    {
+      "text": "This quietly changes everything.",
+      "family": "semantic-thinness",
+      "bucket": "hits",
+      "source": "cases/semantic-thinness/hits.md",
+      "line": 281
+    },
+    {
+      "text": "That subtly reshapes everything.",
+      "family": "semantic-thinness",
+      "bucket": "hits",
+      "source": "cases/semantic-thinness/hits.md",
+      "line": 283
+    },
+    {
+      "text": "A quiet shift is underway.",
+      "family": "semantic-thinness",
+      "bucket": "hits",
+      "source": "cases/semantic-thinness/hits.md",
+      "line": 285
+    },
+    {
+      "text": "The subtle shift is happening.",
+      "family": "semantic-thinness",
+      "bucket": "hits",
+      "source": "cases/semantic-thinness/hits.md",
+      "line": 287
+    },
+    {
+      "text": "This broader shift has begun.",
+      "family": "semantic-thinness",
+      "bucket": "hits",
+      "source": "cases/semantic-thinness/hits.md",
+      "line": 289
+    },
+    {
+      "text": "A meaningful shift is already here.",
+      "family": "semantic-thinness",
+      "bucket": "hits",
+      "source": "cases/semantic-thinness/hits.md",
+      "line": 291
+    },
+    {
+      "text": "The important shift is easy to miss.",
+      "family": "semantic-thinness",
+      "bucket": "hits",
+      "source": "cases/semantic-thinness/hits.md",
+      "line": 293
+    },
+    {
+      "text": "The fundamental shift is hard to ignore.",
+      "family": "semantic-thinness",
+      "bucket": "hits",
+      "source": "cases/semantic-thinness/hits.md",
+      "line": 295
+    },
+    {
+      "text": "The structural shift matters.",
+      "family": "semantic-thinness",
+      "bucket": "hits",
+      "source": "cases/semantic-thinness/hits.md",
+      "line": 297
+    },
+    {
+      "text": "The profound shift changes everything.",
+      "family": "semantic-thinness",
+      "bucket": "hits",
+      "source": "cases/semantic-thinness/hits.md",
+      "line": 299
+    },
+    {
+      "text": "This marks a broader shift.",
+      "family": "semantic-thinness",
+      "bucket": "hits",
+      "source": "cases/semantic-thinness/hits.md",
+      "line": 301
+    },
+    {
+      "text": "That signals a seismic shift.",
+      "family": "semantic-thinness",
+      "bucket": "hits",
+      "source": "cases/semantic-thinness/hits.md",
+      "line": 303
+    },
+    {
+      "text": "This represents a meaningful shift.",
+      "family": "semantic-thinness",
+      "bucket": "hits",
+      "source": "cases/semantic-thinness/hits.md",
+      "line": 305
+    },
+    {
+      "text": "This reflects a notable shift.",
+      "family": "semantic-thinness",
+      "bucket": "hits",
+      "source": "cases/semantic-thinness/hits.md",
+      "line": 307
+    },
+    {
+      "text": "The nurse carefully shifted the tray toward the patient.",
+      "family": "semantic-thinness",
+      "bucket": "no-hits",
+      "source": "cases/semantic-thinness/no-hits.md",
+      "line": 287
+    },
+    {
+      "text": "Please shift slowly so the baby stays asleep.",
+      "family": "semantic-thinness",
+      "bucket": "no-hits",
+      "source": "cases/semantic-thinness/no-hits.md",
+      "line": 289
+    },
+    {
+      "text": "The agency formally removed rule 14 on July 1.",
+      "family": "semantic-thinness",
+      "bucket": "no-hits",
+      "source": "cases/semantic-thinness/no-hits.md",
+      "line": 291
+    },
+    {
+      "text": "The transmission shifted smoothly after the mechanic replaced the worn bearing.",
+      "family": "semantic-thinness",
+      "bucket": "no-hits",
+      "source": "cases/semantic-thinness/no-hits.md",
+      "line": 293
+    },
+    {
+      "text": "The market shifted 3 points after the rate announcement.",
+      "family": "semantic-thinness",
+      "bucket": "no-hits",
+      "source": "cases/semantic-thinness/no-hits.md",
+      "line": 295
+    },
+    {
+      "text": "The team shifted the launch from Monday to Thursday.",
+      "family": "semantic-thinness",
+      "bucket": "no-hits",
+      "source": "cases/semantic-thinness/no-hits.md",
+      "line": 297
+    },
+    {
+      "text": "Search is quietly changing from keyword matching to vector retrieval.",
+      "family": "semantic-thinness",
+      "bucket": "no-hits",
+      "source": "cases/semantic-thinness/no-hits.md",
+      "line": 299
+    },
+    {
+      "text": "The web is gradually moving from HTTP/1.1 to HTTP/2.",
+      "family": "semantic-thinness",
+      "bucket": "no-hits",
+      "source": "cases/semantic-thinness/no-hits.md",
+      "line": 301
+    },
+    {
+      "text": "The platform is steadily processing 40 events per second.",
+      "family": "semantic-thinness",
+      "bucket": "no-hits",
+      "source": "cases/semantic-thinness/no-hits.md",
+      "line": 303
+    },
+    {
+      "text": "The system explicitly changed the retry limit from 3 to 5.",
+      "family": "semantic-thinness",
+      "bucket": "no-hits",
+      "source": "cases/semantic-thinness/no-hits.md",
+      "line": 305
+    },
+    {
+      "text": "A major shift from desktop to mobile cut support calls.",
+      "family": "semantic-thinness",
+      "bucket": "no-hits",
+      "source": "cases/semantic-thinness/no-hits.md",
+      "line": 307
+    },
+    {
+      "text": "The night shift begins at 22:00.",
+      "family": "semantic-thinness",
+      "bucket": "no-hits",
+      "source": "cases/semantic-thinness/no-hits.md",
+      "line": 309
+    },
+    {
+      "text": "Press Shift while clicking the second row.",
+      "family": "semantic-thinness",
+      "bucket": "no-hits",
+      "source": "cases/semantic-thinness/no-hits.md",
+      "line": 311
+    },
+    {
+      "text": "This marks a 4-point shift in the survey.",
+      "family": "semantic-thinness",
+      "bucket": "no-hits",
+      "source": "cases/semantic-thinness/no-hits.md",
+      "line": 313
+    },
+    {
+      "text": "That reflects the shift from cash to card payments.",
+      "family": "semantic-thinness",
+      "bucket": "no-hits",
+      "source": "cases/semantic-thinness/no-hits.md",
+      "line": 315
+    },
+    {
+      "text": "The structural shift in tax law took effect on July 1.",
+      "family": "semantic-thinness",
+      "bucket": "no-hits",
+      "source": "cases/semantic-thinness/no-hits.md",
+      "line": 317
+    },
+    {
+      "text": "The platform subtly evolves.",
+      "family": "semantic-thinness",
+      "bucket": "hits",
+      "source": "cases/semantic-thinness/hits.md",
+      "line": 309
+    },
+    {
+      "text": "The market quietly shifted.",
+      "family": "semantic-thinness",
+      "bucket": "hits",
+      "source": "cases/semantic-thinness/hits.md",
+      "line": 311
+    },
+    {
+      "text": "The web was silently transforming.",
+      "family": "semantic-thinness",
+      "bucket": "hits",
+      "source": "cases/semantic-thinness/hits.md",
+      "line": 313
+    },
+    {
+      "text": "The industry has quietly changed.",
+      "family": "semantic-thinness",
+      "bucket": "hits",
+      "source": "cases/semantic-thinness/hits.md",
+      "line": 315
+    },
+    {
+      "text": "The model had quietly changed.",
+      "family": "semantic-thinness",
+      "bucket": "hits",
+      "source": "cases/semantic-thinness/hits.md",
+      "line": 317
+    },
+    {
+      "text": "The system shifted quietly.",
+      "family": "semantic-thinness",
+      "bucket": "hits",
+      "source": "cases/semantic-thinness/hits.md",
+      "line": 319
+    },
+    {
+      "text": "The platform subtly evolves after each weekly model update.",
+      "family": "semantic-thinness",
+      "bucket": "no-hits",
+      "source": "cases/semantic-thinness/no-hits.md",
+      "line": 319
+    },
+    {
+      "text": "The market quietly shifted 3 points after the rate announcement.",
+      "family": "semantic-thinness",
+      "bucket": "no-hits",
+      "source": "cases/semantic-thinness/no-hits.md",
+      "line": 321
+    },
+    {
+      "text": "The web was silently transforming 40 records per second.",
+      "family": "semantic-thinness",
+      "bucket": "no-hits",
+      "source": "cases/semantic-thinness/no-hits.md",
+      "line": 323
+    },
+    {
+      "text": "The industry has quietly changed from annual contracts to monthly plans.",
+      "family": "semantic-thinness",
+      "bucket": "no-hits",
+      "source": "cases/semantic-thinness/no-hits.md",
+      "line": 325
+    },
+    {
+      "text": "The model had quietly changed from version 2 to version 3.",
+      "family": "semantic-thinness",
+      "bucket": "no-hits",
+      "source": "cases/semantic-thinness/no-hits.md",
+      "line": 327
+    },
+    {
+      "text": "The system shifted quietly after the operator replaced the worn bearing.",
+      "family": "semantic-thinness",
+      "bucket": "no-hits",
+      "source": "cases/semantic-thinness/no-hits.md",
+      "line": 329
     }
   ]
 }

--- a/behavior/golden/textlint-rules-cases-orthography/approved.meta.json
+++ b/behavior/golden/textlint-rules-cases-orthography/approved.meta.json
@@ -1,10 +1,10 @@
 {
   "suite": "textlint-rules-cases-orthography",
   "kind": "approved",
-  "run_id": "2026-07-24T10-31-13.344378Z-04547efb",
-  "run_commit": "ddf8160",
+  "run_id": "2026-07-24T19-12-35.157487Z-04547efb",
+  "run_commit": "51aa56d",
   "working_tree": "dirty",
-  "recorded_at": "2026-07-24T10:31:13.344378Z",
+  "recorded_at": "2026-07-24T19:12:35.157487Z",
   "fixture_hash": "sha256:74a72297ebd7d502036486c42e25639a8f1c55f2979e1214524b8ca52af192b2",
   "manifest_hash": "sha256:04547efbb13157ee3d8ef18dda767231fd63d3f9cc27c15317cf28c5f0583e7b",
   "tool_version": "0.1.8",
@@ -19,5 +19,5 @@
       "sha256": "sha256:03069f8f140a3f5ebb9d9c40c67c831b422ed2116b68c8ddcc434e74685b769b"
     }
   ],
-  "comment": "Normalize fixture paths relative to repository; findings unchanged"
+  "comment": "Reviewed vague-change templates, quietly density, and corrected document source offsets."
 }

--- a/behavior/golden/textlint-rules-cases-orthography/approved.normalized.json
+++ b/behavior/golden/textlint-rules-cases-orthography/approved.normalized.json
@@ -8,75 +8,6 @@
         "line": 1,
         "loc": {
           "end": {
-            "column": 2,
-            "line": 1
-          },
-          "start": {
-            "column": 1,
-            "line": 1
-          }
-        },
-        "message": "Coleman-Liau is 12.37. Keep it at 12 or lower.",
-        "range": [
-          0,
-          1
-        ],
-        "ruleId": "coleman-liau",
-        "severity": 2,
-        "type": "lint"
-      },
-      {
-        "column": 1,
-        "index": 0,
-        "line": 1,
-        "loc": {
-          "end": {
-            "column": 2,
-            "line": 1
-          },
-          "start": {
-            "column": 1,
-            "line": 1
-          }
-        },
-        "message": "Flesch Reading Ease is 49.01. Keep it at 61 or higher.",
-        "range": [
-          0,
-          1
-        ],
-        "ruleId": "flesch-kincaid",
-        "severity": 2,
-        "type": "lint"
-      },
-      {
-        "column": 1,
-        "index": 0,
-        "line": 1,
-        "loc": {
-          "end": {
-            "column": 2,
-            "line": 1
-          },
-          "start": {
-            "column": 1,
-            "line": 1
-          }
-        },
-        "message": "Gunning Fog is 18.41. Keep it at 12 or lower.",
-        "range": [
-          0,
-          1
-        ],
-        "ruleId": "gunning-fog",
-        "severity": 2,
-        "type": "lint"
-      },
-      {
-        "column": 1,
-        "index": 0,
-        "line": 1,
-        "loc": {
-          "end": {
             "column": 34,
             "line": 1
           },
@@ -91,6 +22,75 @@
           33
         ],
         "ruleId": "sentence-case",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 35,
+        "line": 3,
+        "loc": {
+          "end": {
+            "column": 2,
+            "line": 3
+          },
+          "start": {
+            "column": 1,
+            "line": 3
+          }
+        },
+        "message": "Coleman-Liau is 12.37. Keep it at 12 or lower.",
+        "range": [
+          35,
+          36
+        ],
+        "ruleId": "coleman-liau",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 35,
+        "line": 3,
+        "loc": {
+          "end": {
+            "column": 2,
+            "line": 3
+          },
+          "start": {
+            "column": 1,
+            "line": 3
+          }
+        },
+        "message": "Flesch Reading Ease is 49.01. Keep it at 61 or higher.",
+        "range": [
+          35,
+          36
+        ],
+        "ruleId": "flesch-kincaid",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 35,
+        "line": 3,
+        "loc": {
+          "end": {
+            "column": 2,
+            "line": 3
+          },
+          "start": {
+            "column": 1,
+            "line": 3
+          }
+        },
+        "message": "Gunning Fog is 18.41. Keep it at 12 or lower.",
+        "range": [
+          35,
+          36
+        ],
+        "ruleId": "gunning-fog",
         "severity": 2,
         "type": "lint"
       },
@@ -791,22 +791,22 @@
     "messages": [
       {
         "column": 1,
-        "index": 0,
-        "line": 1,
+        "index": 93,
+        "line": 7,
         "loc": {
           "end": {
             "column": 2,
-            "line": 1
+            "line": 7
           },
           "start": {
             "column": 1,
-            "line": 1
+            "line": 7
           }
         },
         "message": "Coleman-Liau is 12.84. Keep it at 12 or lower.",
         "range": [
-          0,
-          1
+          93,
+          94
         ],
         "ruleId": "coleman-liau",
         "severity": 2,
@@ -814,22 +814,22 @@
       },
       {
         "column": 1,
-        "index": 0,
-        "line": 1,
+        "index": 93,
+        "line": 7,
         "loc": {
           "end": {
             "column": 2,
-            "line": 1
+            "line": 7
           },
           "start": {
             "column": 1,
-            "line": 1
+            "line": 7
           }
         },
         "message": "Flesch Reading Ease is 21.71. Keep it at 61 or higher.",
         "range": [
-          0,
-          1
+          93,
+          94
         ],
         "ruleId": "flesch-kincaid",
         "severity": 2,
@@ -837,22 +837,22 @@
       },
       {
         "column": 1,
-        "index": 0,
-        "line": 1,
+        "index": 93,
+        "line": 7,
         "loc": {
           "end": {
             "column": 2,
-            "line": 1
+            "line": 7
           },
           "start": {
             "column": 1,
-            "line": 1
+            "line": 7
           }
         },
         "message": "Gunning Fog is 28.72. Keep it at 12 or lower.",
         "range": [
-          0,
-          1
+          93,
+          94
         ],
         "ruleId": "gunning-fog",
         "severity": 2,

--- a/behavior/golden/textlint-rules-cases-semantic-thinness/approved.meta.json
+++ b/behavior/golden/textlint-rules-cases-semantic-thinness/approved.meta.json
@@ -1,23 +1,23 @@
 {
   "suite": "textlint-rules-cases-semantic-thinness",
   "kind": "approved",
-  "run_id": "2026-07-24T10-31-24.354827Z-04547efb",
-  "run_commit": "ddf8160",
+  "run_id": "2026-07-24T19-12-45.427836Z-04547efb",
+  "run_commit": "51aa56d",
   "working_tree": "dirty",
-  "recorded_at": "2026-07-24T10:31:24.354827Z",
-  "fixture_hash": "sha256:36673048ad0dd9979d27f9a46c28e74ae904a3be9e3a25b0f33db2c2b7cb6cbb",
+  "recorded_at": "2026-07-24T19:12:45.427836Z",
+  "fixture_hash": "sha256:cdd72aebaed2528dd027df319b052870ae5dfafd72157b6b57fc4c5564339d75",
   "manifest_hash": "sha256:04547efbb13157ee3d8ef18dda767231fd63d3f9cc27c15317cf28c5f0583e7b",
   "tool_version": "0.1.8",
   "output_schema_version": "1",
   "fixtures": [
     {
       "path": "behavior/fixtures/textlint-rules/cases/semantic-thinness/hits.md",
-      "sha256": "sha256:304e78a085ccdbf12422acf41c5a20fb25e2e14fe396e6519e3e2f5cfdc7a8d3"
+      "sha256": "sha256:72dc704ac44291602591badf584bf9791bcd3c0aebcfdd961b81e4c79e90ce38"
     },
     {
       "path": "behavior/fixtures/textlint-rules/cases/semantic-thinness/no-hits.md",
-      "sha256": "sha256:b9a684ba55a5ae1d9a238a09c2d8ecfa992fbaac6c26b56ce137c48b1b93c896"
+      "sha256": "sha256:6b8fd794ae57e5bbbe2cde072d9bf773dcb25ca4c04f2ec7adb8a4b982fd6e32"
     }
   ],
-  "comment": "Normalize fixture paths relative to repository; findings unchanged"
+  "comment": "Reviewed vague-change templates, quietly density, and corrected document source offsets."
 }

--- a/behavior/golden/textlint-rules-cases-semantic-thinness/approved.normalized.json
+++ b/behavior/golden/textlint-rules-cases-semantic-thinness/approved.normalized.json
@@ -16,7 +16,7 @@
             "line": 1
           }
         },
-        "message": "Coleman-Liau is 12.45. Keep it at 12 or lower.",
+        "message": "Coleman-Liau is 13.03. Keep it at 12 or lower.",
         "range": [
           0,
           1
@@ -39,7 +39,7 @@
             "line": 1
           }
         },
-        "message": "Flesch Reading Ease is -303.74. Keep it at 61 or higher.",
+        "message": "Flesch Reading Ease is -347.39. Keep it at 61 or higher.",
         "range": [
           0,
           1
@@ -62,7 +62,7 @@
             "line": 1
           }
         },
-        "message": "Gunning Fog is 153.77. Keep it at 12 or lower.",
+        "message": "Gunning Fog is 171.16. Keep it at 12 or lower.",
         "range": [
           0,
           1
@@ -3642,7 +3642,7 @@
         "line": 269,
         "loc": {
           "end": {
-            "column": 20,
+            "column": 32,
             "line": 269
           },
           "start": {
@@ -3650,22 +3650,57 @@
             "line": 269
           }
         },
-        "message": "Semantic thinness (deictic-summary): Catch deictic summary pronouncements that point at a supposed lesson, truth, promise, or part without naming the concrete claim. Matched template: {deicticCopula} the {summaryNoun}.",
+        "message": "Semantic thinness (something-shifted): Catch vague change declarations that say something shifted, changed, moved, or crossed a line without naming the concrete change. Matched template: {diffuseSubject} {progressiveAuxiliary} {weakMannerAdverb} {progressiveChange}.",
         "range": [
           6106,
-          6125
+          6137
         ],
         "ruleId": "semantic-thinness",
         "severity": 2,
         "type": "lint"
       },
       {
+        "column": 15,
+        "data": {
+          "message": "\"quietly\" used 6 times (4.8 per 1,000 words), above the 2-per-1,000-word error threshold. Cut the filler uses; keep at most about one per 1,000 words.",
+          "padding": {
+            "isAbsolute": false,
+            "range": [
+              6120,
+              6127
+            ],
+            "type": "TextlintRuleErrorPaddingLocation"
+          },
+          "severity": 2
+        },
+        "index": 6120,
+        "line": 269,
+        "loc": {
+          "end": {
+            "column": 22,
+            "line": 269
+          },
+          "start": {
+            "column": 15,
+            "line": 269
+          }
+        },
+        "message": "\"quietly\" used 6 times (4.8 per 1,000 words), above the 2-per-1,000-word error threshold. Cut the filler uses; keep at most about one per 1,000 words.",
+        "range": [
+          6120,
+          6127
+        ],
+        "ruleId": "quietly-overuse",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
         "column": 1,
-        "index": 6127,
+        "index": 6139,
         "line": 271,
         "loc": {
           "end": {
-            "column": 26,
+            "column": 33,
             "line": 271
           },
           "start": {
@@ -3673,10 +3708,10 @@
             "line": 271
           }
         },
-        "message": "Semantic thinness (deictic-summary): Catch deictic summary pronouncements that point at a supposed lesson, truth, promise, or part without naming the concrete claim. Matched template: {deicticCopula} the {evaluativeAdjective} {summaryNoun}.",
+        "message": "Semantic thinness (something-shifted): Catch vague change declarations that say something shifted, changed, moved, or crossed a line without naming the concrete change. Matched template: {diffuseSubject} {progressiveAuxiliary} {weakMannerAdverb} {progressiveChange}.",
         "range": [
-          6127,
-          6152
+          6139,
+          6171
         ],
         "ruleId": "semantic-thinness",
         "severity": 2,
@@ -3684,11 +3719,11 @@
       },
       {
         "column": 1,
-        "index": 6154,
+        "index": 6173,
         "line": 273,
         "loc": {
           "end": {
-            "column": 24,
+            "column": 30,
             "line": 273
           },
           "start": {
@@ -3696,10 +3731,10 @@
             "line": 273
           }
         },
-        "message": "Semantic thinness (deictic-summary): Catch deictic summary pronouncements that point at a supposed lesson, truth, promise, or part without naming the concrete claim. Matched template: {deicticCopula} the {evaluativeAdjective} {summaryNoun}.",
+        "message": "Semantic thinness (something-shifted): Catch vague change declarations that say something shifted, changed, moved, or crossed a line without naming the concrete change. Matched template: {diffuseSubject} {progressiveAuxiliary} {weakMannerAdverb} {progressiveChange}.",
         "range": [
-          6154,
-          6177
+          6173,
+          6202
         ],
         "ruleId": "semantic-thinness",
         "severity": 2,
@@ -3707,11 +3742,11 @@
       },
       {
         "column": 1,
-        "index": 6179,
+        "index": 6204,
         "line": 275,
         "loc": {
           "end": {
-            "column": 60,
+            "column": 34,
             "line": 275
           },
           "start": {
@@ -3719,10 +3754,10 @@
             "line": 275
           }
         },
-        "message": "Semantic thinness (abstract-metaphor-claim): Catch slogan-like abstract metaphors where an abstract subject performs a physical or spatial action with no concrete referent. Matched template: {audiencePreposition} the {automatedAudience} {audienceActivity}, the {identityArtifact} {linkingVerb} the {artifactRole}.",
+        "message": "Semantic thinness (something-shifted): Catch vague change declarations that say something shifted, changed, moved, or crossed a line without naming the concrete change. Matched template: {diffuseSubject} {progressiveAuxiliary} {weakMannerAdverb} {progressiveChange}.",
         "range": [
-          6179,
-          6238
+          6204,
+          6237
         ],
         "ruleId": "semantic-thinness",
         "severity": 2,
@@ -3730,11 +3765,11 @@
       },
       {
         "column": 1,
-        "index": 6240,
+        "index": 6239,
         "line": 277,
         "loc": {
           "end": {
-            "column": 46,
+            "column": 37,
             "line": 277
           },
           "start": {
@@ -3742,10 +3777,10 @@
             "line": 277
           }
         },
-        "message": "Semantic thinness (abstract-metaphor-claim): Catch slogan-like abstract metaphors where an abstract subject performs a physical or spatial action with no concrete referent. Matched template: {audiencePreposition} the {automatedAudience}, the {identityArtifact} {linkingVerb} the {artifactRole}.",
+        "message": "Semantic thinness (something-shifted): Catch vague change declarations that say something shifted, changed, moved, or crossed a line without naming the concrete change. Matched template: {diffuseSubject} {progressiveAuxiliary} {weakMannerAdverb} {progressiveChange}.",
         "range": [
-          6240,
-          6285
+          6239,
+          6275
         ],
         "ruleId": "semantic-thinness",
         "severity": 2,
@@ -3753,11 +3788,11 @@
       },
       {
         "column": 1,
-        "index": 6287,
+        "index": 6277,
         "line": 279,
         "loc": {
           "end": {
-            "column": 53,
+            "column": 45,
             "line": 279
           },
           "start": {
@@ -3765,10 +3800,10 @@
             "line": 279
           }
         },
-        "message": "Semantic thinness (abstract-metaphor-claim): Catch slogan-like abstract metaphors where an abstract subject performs a physical or spatial action with no concrete referent. Matched template: {audiencePreposition} the {automatedAudience}, the {identityArtifact} {linkingVerb} the {artifactRole}.",
+        "message": "Semantic thinness (something-shifted): Catch vague change declarations that say something shifted, changed, moved, or crossed a line without naming the concrete change. Matched template: {diffuseSubject} {progressiveAuxiliary} {weakMannerAdverb} {progressiveChange}.",
         "range": [
-          6287,
-          6339
+          6277,
+          6321
         ],
         "ruleId": "semantic-thinness",
         "severity": 2,
@@ -3776,11 +3811,11 @@
       },
       {
         "column": 1,
-        "index": 6341,
+        "index": 6323,
         "line": 281,
         "loc": {
           "end": {
-            "column": 44,
+            "column": 33,
             "line": 281
           },
           "start": {
@@ -3788,10 +3823,10 @@
             "line": 281
           }
         },
-        "message": "Semantic thinness (abstract-metaphor-claim): Catch slogan-like abstract metaphors where an abstract subject performs a physical or spatial action with no concrete referent. Matched template: {audiencePreposition} the {automatedAudience}, {identityArtifact} {linkingVerb} the {artifactRole}.",
+        "message": "Semantic thinness (something-shifted): Catch vague change declarations that say something shifted, changed, moved, or crossed a line without naming the concrete change. Matched template: {deicticSubject} {weakMannerAdverb} {emptyChangeObject}.",
         "range": [
-          6341,
-          6384
+          6323,
+          6355
         ],
         "ruleId": "semantic-thinness",
         "severity": 2,
@@ -3799,11 +3834,11 @@
       },
       {
         "column": 1,
-        "index": 6386,
+        "index": 6357,
         "line": 283,
         "loc": {
           "end": {
-            "column": 28,
+            "column": 33,
             "line": 283
           },
           "start": {
@@ -3811,33 +3846,10 @@
             "line": 283
           }
         },
-        "message": "Demonstrative emphasis found: \"The prompt is the strategy.\". Reduce repeated short emphasis lines.",
+        "message": "Semantic thinness (something-shifted): Catch vague change declarations that say something shifted, changed, moved, or crossed a line without naming the concrete change. Matched template: {deicticSubject} {weakMannerAdverb} {emptyChangeObject}.",
         "range": [
-          6386,
-          6413
-        ],
-        "ruleId": "demonstrative-emphasis",
-        "severity": 2,
-        "type": "lint"
-      },
-      {
-        "column": 1,
-        "index": 6386,
-        "line": 283,
-        "loc": {
-          "end": {
-            "column": 28,
-            "line": 283
-          },
-          "start": {
-            "column": 1,
-            "line": 283
-          }
-        },
-        "message": "Semantic thinness (abstract-metaphor-claim): Catch slogan-like abstract metaphors where an abstract subject performs a physical or spatial action with no concrete referent. Matched template: the {identityArtifact} {linkingVerb} the {artifactRole}.",
-        "range": [
-          6386,
-          6413
+          6357,
+          6389
         ],
         "ruleId": "semantic-thinness",
         "severity": 2,
@@ -3845,11 +3857,11 @@
       },
       {
         "column": 1,
-        "index": 6415,
+        "index": 6391,
         "line": 285,
         "loc": {
           "end": {
-            "column": 31,
+            "column": 27,
             "line": 285
           },
           "start": {
@@ -3857,33 +3869,10 @@
             "line": 285
           }
         },
-        "message": "Demonstrative emphasis found: \"The dashboard is the decision.\". Reduce repeated short emphasis lines.",
+        "message": "Semantic thinness (something-shifted): Catch vague change declarations that say something shifted, changed, moved, or crossed a line without naming the concrete change. Matched template: {shiftDeterminer} {shiftModifier} shift {emptyShiftPredicate}.",
         "range": [
-          6415,
-          6445
-        ],
-        "ruleId": "demonstrative-emphasis",
-        "severity": 2,
-        "type": "lint"
-      },
-      {
-        "column": 1,
-        "index": 6415,
-        "line": 285,
-        "loc": {
-          "end": {
-            "column": 31,
-            "line": 285
-          },
-          "start": {
-            "column": 1,
-            "line": 285
-          }
-        },
-        "message": "Semantic thinness (abstract-metaphor-claim): Catch slogan-like abstract metaphors where an abstract subject performs a physical or spatial action with no concrete referent. Matched template: the {identityArtifact} {linkingVerb} the {artifactRole}.",
-        "range": [
-          6415,
-          6445
+          6391,
+          6417
         ],
         "ruleId": "semantic-thinness",
         "severity": 2,
@@ -3891,22 +3880,45 @@
       },
       {
         "column": 1,
-        "index": 6447,
+        "index": 6419,
         "line": 287,
         "loc": {
           "end": {
+            "column": 31,
+            "line": 287
+          },
+          "start": {
+            "column": 1,
+            "line": 287
+          }
+        },
+        "message": "Semantic thinness (something-shifted): Catch vague change declarations that say something shifted, changed, moved, or crossed a line without naming the concrete change. Matched template: {shiftDeterminer} {shiftModifier} shift {emptyShiftPredicate}.",
+        "range": [
+          6419,
+          6449
+        ],
+        "ruleId": "semantic-thinness",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 6451,
+        "line": 289,
+        "loc": {
+          "end": {
             "column": 30,
-            "line": 287
+            "line": 289
           },
           "start": {
             "column": 1,
-            "line": 287
+            "line": 289
           }
         },
-        "message": "Semantic thinness (abstract-metaphor-claim): Catch slogan-like abstract metaphors where an abstract subject performs a physical or spatial action with no concrete referent. Matched template: the {identityArtifact} {linkingVerb} the {artifactRole}.",
+        "message": "Semantic thinness (something-shifted): Catch vague change declarations that say something shifted, changed, moved, or crossed a line without naming the concrete change. Matched template: {shiftDeterminer} {shiftModifier} shift {emptyShiftPredicate}.",
         "range": [
-          6447,
-          6476
+          6451,
+          6480
         ],
         "ruleId": "semantic-thinness",
         "severity": 2,
@@ -3914,57 +3926,11 @@
       },
       {
         "column": 1,
-        "index": 6478,
-        "line": 289,
-        "loc": {
-          "end": {
-            "column": 33,
-            "line": 289
-          },
-          "start": {
-            "column": 1,
-            "line": 289
-          }
-        },
-        "message": "Demonstrative emphasis found: \"The spreadsheet is the business.\". Reduce repeated short emphasis lines.",
-        "range": [
-          6478,
-          6510
-        ],
-        "ruleId": "demonstrative-emphasis",
-        "severity": 2,
-        "type": "lint"
-      },
-      {
-        "column": 1,
-        "index": 6478,
-        "line": 289,
-        "loc": {
-          "end": {
-            "column": 33,
-            "line": 289
-          },
-          "start": {
-            "column": 1,
-            "line": 289
-          }
-        },
-        "message": "Semantic thinness (abstract-metaphor-claim): Catch slogan-like abstract metaphors where an abstract subject performs a physical or spatial action with no concrete referent. Matched template: the {identityArtifact} {linkingVerb} the {artifactRole}.",
-        "range": [
-          6478,
-          6510
-        ],
-        "ruleId": "semantic-thinness",
-        "severity": 2,
-        "type": "lint"
-      },
-      {
-        "column": 1,
-        "index": 6512,
+        "index": 6482,
         "line": 291,
         "loc": {
           "end": {
-            "column": 25,
+            "column": 36,
             "line": 291
           },
           "start": {
@@ -3972,33 +3938,10 @@
             "line": 291
           }
         },
-        "message": "Demonstrative emphasis found: \"The index is the market.\". Reduce repeated short emphasis lines.",
+        "message": "Semantic thinness (something-shifted): Catch vague change declarations that say something shifted, changed, moved, or crossed a line without naming the concrete change. Matched template: {shiftDeterminer} {shiftModifier} shift {emptyShiftPredicate}.",
         "range": [
-          6512,
-          6536
-        ],
-        "ruleId": "demonstrative-emphasis",
-        "severity": 2,
-        "type": "lint"
-      },
-      {
-        "column": 1,
-        "index": 6512,
-        "line": 291,
-        "loc": {
-          "end": {
-            "column": 25,
-            "line": 291
-          },
-          "start": {
-            "column": 1,
-            "line": 291
-          }
-        },
-        "message": "Semantic thinness (abstract-metaphor-claim): Catch slogan-like abstract metaphors where an abstract subject performs a physical or spatial action with no concrete referent. Matched template: the {identityArtifact} {linkingVerb} the {artifactRole}.",
-        "range": [
-          6512,
-          6536
+          6482,
+          6517
         ],
         "ruleId": "semantic-thinness",
         "severity": 2,
@@ -4006,11 +3949,11 @@
       },
       {
         "column": 1,
-        "index": 6538,
+        "index": 6519,
         "line": 293,
         "loc": {
           "end": {
-            "column": 26,
+            "column": 37,
             "line": 293
           },
           "start": {
@@ -4018,22 +3961,22 @@
             "line": 293
           }
         },
-        "message": "Demonstrative emphasis found: \"The pipeline is the work.\". Reduce repeated short emphasis lines.",
+        "message": "Generic signposting found: the-important-shift-is. Replace the frame with the concrete claim.",
         "range": [
-          6538,
-          6563
+          6519,
+          6555
         ],
-        "ruleId": "demonstrative-emphasis",
+        "ruleId": "generic-signposting",
         "severity": 2,
         "type": "lint"
       },
       {
         "column": 1,
-        "index": 6538,
+        "index": 6519,
         "line": 293,
         "loc": {
           "end": {
-            "column": 26,
+            "column": 37,
             "line": 293
           },
           "start": {
@@ -4041,10 +3984,10 @@
             "line": 293
           }
         },
-        "message": "Semantic thinness (abstract-metaphor-claim): Catch slogan-like abstract metaphors where an abstract subject performs a physical or spatial action with no concrete referent. Matched template: the {identityArtifact} {linkingVerb} the {artifactRole}.",
+        "message": "Semantic thinness (something-shifted): Catch vague change declarations that say something shifted, changed, moved, or crossed a line without naming the concrete change. Matched template: {shiftDeterminer} {shiftModifier} shift {emptyShiftPredicate}.",
         "range": [
-          6538,
-          6563
+          6519,
+          6555
         ],
         "ruleId": "semantic-thinness",
         "severity": 2,
@@ -4052,11 +3995,11 @@
       },
       {
         "column": 1,
-        "index": 6565,
+        "index": 6557,
         "line": 295,
         "loc": {
           "end": {
-            "column": 33,
+            "column": 41,
             "line": 295
           },
           "start": {
@@ -4064,32 +4007,9 @@
             "line": 295
           }
         },
-        "message": "Demonstrative emphasis found: \"The interface is the experience.\". Reduce repeated short emphasis lines.",
+        "message": "Semantic thinness (something-shifted): Catch vague change declarations that say something shifted, changed, moved, or crossed a line without naming the concrete change. Matched template: {shiftDeterminer} {shiftModifier} shift {emptyShiftPredicate}.",
         "range": [
-          6565,
-          6597
-        ],
-        "ruleId": "demonstrative-emphasis",
-        "severity": 2,
-        "type": "lint"
-      },
-      {
-        "column": 1,
-        "index": 6565,
-        "line": 295,
-        "loc": {
-          "end": {
-            "column": 33,
-            "line": 295
-          },
-          "start": {
-            "column": 1,
-            "line": 295
-          }
-        },
-        "message": "Semantic thinness (abstract-metaphor-claim): Catch slogan-like abstract metaphors where an abstract subject performs a physical or spatial action with no concrete referent. Matched template: the {identityArtifact} {linkingVerb} the {artifactRole}.",
-        "range": [
-          6565,
+          6557,
           6597
         ],
         "ruleId": "semantic-thinness",
@@ -4102,7 +4022,7 @@
         "line": 297,
         "loc": {
           "end": {
-            "column": 36,
+            "column": 30,
             "line": 297
           },
           "start": {
@@ -4110,10 +4030,10 @@
             "line": 297
           }
         },
-        "message": "Semantic thinness (abstract-metaphor-claim): Catch slogan-like abstract metaphors where an abstract subject performs a physical or spatial action with no concrete referent. Matched template: the {identityArtifact} {linkingVerb} the {artifactRole}.",
+        "message": "Semantic thinness (something-shifted): Catch vague change declarations that say something shifted, changed, moved, or crossed a line without naming the concrete change. Matched template: {shiftDeterminer} {shiftModifier} shift {emptyShiftPredicate}.",
         "range": [
           6599,
-          6634
+          6628
         ],
         "ruleId": "semantic-thinness",
         "severity": 2,
@@ -4121,11 +4041,11 @@
       },
       {
         "column": 1,
-        "index": 6636,
+        "index": 6630,
         "line": 299,
         "loc": {
           "end": {
-            "column": 32,
+            "column": 39,
             "line": 299
           },
           "start": {
@@ -4133,10 +4053,447 @@
             "line": 299
           }
         },
-        "message": "Demonstrative emphasis found: \"So the feed is the product now.\". Reduce repeated short emphasis lines.",
+        "message": "Semantic thinness (something-shifted): Catch vague change declarations that say something shifted, changed, moved, or crossed a line without naming the concrete change. Matched template: {shiftDeterminer} {shiftModifier} shift {emptyShiftPredicate}.",
         "range": [
-          6636,
-          6667
+          6630,
+          6668
+        ],
+        "ruleId": "semantic-thinness",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 6670,
+        "line": 301,
+        "loc": {
+          "end": {
+            "column": 28,
+            "line": 301
+          },
+          "start": {
+            "column": 1,
+            "line": 301
+          }
+        },
+        "message": "Semantic thinness (something-shifted): Catch vague change declarations that say something shifted, changed, moved, or crossed a line without naming the concrete change. Matched template: {deicticSubject} {signalVerb} {shiftDeterminer} {shiftModifier} shift.",
+        "range": [
+          6670,
+          6697
+        ],
+        "ruleId": "semantic-thinness",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 6699,
+        "line": 303,
+        "loc": {
+          "end": {
+            "column": 30,
+            "line": 303
+          },
+          "start": {
+            "column": 1,
+            "line": 303
+          }
+        },
+        "message": "Semantic thinness (something-shifted): Catch vague change declarations that say something shifted, changed, moved, or crossed a line without naming the concrete change. Matched template: {deicticSubject} {signalVerb} {shiftDeterminer} {shiftModifier} shift.",
+        "range": [
+          6699,
+          6728
+        ],
+        "ruleId": "semantic-thinness",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 6,
+        "index": 6704,
+        "line": 303,
+        "loc": {
+          "end": {
+            "column": 29,
+            "line": 303
+          },
+          "start": {
+            "column": 6,
+            "line": 303
+          }
+        },
+        "message": "Cliche found: \"signals a seismic shift\". Replace it with specific wording.",
+        "range": [
+          6704,
+          6727
+        ],
+        "ruleId": "cliches",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 6730,
+        "line": 305,
+        "loc": {
+          "end": {
+            "column": 36,
+            "line": 305
+          },
+          "start": {
+            "column": 1,
+            "line": 305
+          }
+        },
+        "message": "Semantic thinness (something-shifted): Catch vague change declarations that say something shifted, changed, moved, or crossed a line without naming the concrete change. Matched template: {deicticSubject} {signalVerb} {shiftDeterminer} {shiftModifier} shift.",
+        "range": [
+          6730,
+          6765
+        ],
+        "ruleId": "semantic-thinness",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 6767,
+        "line": 307,
+        "loc": {
+          "end": {
+            "column": 31,
+            "line": 307
+          },
+          "start": {
+            "column": 1,
+            "line": 307
+          }
+        },
+        "message": "Semantic thinness (something-shifted): Catch vague change declarations that say something shifted, changed, moved, or crossed a line without naming the concrete change. Matched template: {deicticSubject} {signalVerb} {shiftDeterminer} {shiftModifier} shift.",
+        "range": [
+          6767,
+          6797
+        ],
+        "ruleId": "semantic-thinness",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 6799,
+        "line": 309,
+        "loc": {
+          "end": {
+            "column": 29,
+            "line": 309
+          },
+          "start": {
+            "column": 1,
+            "line": 309
+          }
+        },
+        "message": "Semantic thinness (something-shifted): Catch vague change declarations that say something shifted, changed, moved, or crossed a line without naming the concrete change. Matched template: {diffuseSubject} {weakMannerAdverb} {finiteChange}.",
+        "range": [
+          6799,
+          6827
+        ],
+        "ruleId": "semantic-thinness",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 6829,
+        "line": 311,
+        "loc": {
+          "end": {
+            "column": 28,
+            "line": 311
+          },
+          "start": {
+            "column": 1,
+            "line": 311
+          }
+        },
+        "message": "Semantic thinness (something-shifted): Catch vague change declarations that say something shifted, changed, moved, or crossed a line without naming the concrete change. Matched template: {diffuseSubject} {weakMannerAdverb} {finiteChange}.",
+        "range": [
+          6829,
+          6856
+        ],
+        "ruleId": "semantic-thinness",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 6858,
+        "line": 313,
+        "loc": {
+          "end": {
+            "column": 35,
+            "line": 313
+          },
+          "start": {
+            "column": 1,
+            "line": 313
+          }
+        },
+        "message": "Semantic thinness (something-shifted): Catch vague change declarations that say something shifted, changed, moved, or crossed a line without naming the concrete change. Matched template: {diffuseSubject} {progressiveAuxiliary} {weakMannerAdverb} {progressiveChange}.",
+        "range": [
+          6858,
+          6892
+        ],
+        "ruleId": "semantic-thinness",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 6894,
+        "line": 315,
+        "loc": {
+          "end": {
+            "column": 34,
+            "line": 315
+          },
+          "start": {
+            "column": 1,
+            "line": 315
+          }
+        },
+        "message": "Semantic thinness (something-shifted): Catch vague change declarations that say something shifted, changed, moved, or crossed a line without naming the concrete change. Matched template: {diffuseSubject} {perfectAuxiliary} {weakMannerAdverb} {pastChange}.",
+        "range": [
+          6894,
+          6927
+        ],
+        "ruleId": "semantic-thinness",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 6929,
+        "line": 317,
+        "loc": {
+          "end": {
+            "column": 31,
+            "line": 317
+          },
+          "start": {
+            "column": 1,
+            "line": 317
+          }
+        },
+        "message": "Semantic thinness (something-shifted): Catch vague change declarations that say something shifted, changed, moved, or crossed a line without naming the concrete change. Matched template: {diffuseSubject} {perfectAuxiliary} {weakMannerAdverb} {pastChange}.",
+        "range": [
+          6929,
+          6959
+        ],
+        "ruleId": "semantic-thinness",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 6961,
+        "line": 319,
+        "loc": {
+          "end": {
+            "column": 28,
+            "line": 319
+          },
+          "start": {
+            "column": 1,
+            "line": 319
+          }
+        },
+        "message": "Semantic thinness (something-shifted): Catch vague change declarations that say something shifted, changed, moved, or crossed a line without naming the concrete change. Matched template: {diffuseSubject} {finiteChange} {weakMannerAdverb}.",
+        "range": [
+          6961,
+          6988
+        ],
+        "ruleId": "semantic-thinness",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 6990,
+        "line": 321,
+        "loc": {
+          "end": {
+            "column": 20,
+            "line": 321
+          },
+          "start": {
+            "column": 1,
+            "line": 321
+          }
+        },
+        "message": "Semantic thinness (deictic-summary): Catch deictic summary pronouncements that point at a supposed lesson, truth, promise, or part without naming the concrete claim. Matched template: {deicticCopula} the {summaryNoun}.",
+        "range": [
+          6990,
+          7009
+        ],
+        "ruleId": "semantic-thinness",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 7011,
+        "line": 323,
+        "loc": {
+          "end": {
+            "column": 26,
+            "line": 323
+          },
+          "start": {
+            "column": 1,
+            "line": 323
+          }
+        },
+        "message": "Semantic thinness (deictic-summary): Catch deictic summary pronouncements that point at a supposed lesson, truth, promise, or part without naming the concrete claim. Matched template: {deicticCopula} the {evaluativeAdjective} {summaryNoun}.",
+        "range": [
+          7011,
+          7036
+        ],
+        "ruleId": "semantic-thinness",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 7038,
+        "line": 325,
+        "loc": {
+          "end": {
+            "column": 24,
+            "line": 325
+          },
+          "start": {
+            "column": 1,
+            "line": 325
+          }
+        },
+        "message": "Semantic thinness (deictic-summary): Catch deictic summary pronouncements that point at a supposed lesson, truth, promise, or part without naming the concrete claim. Matched template: {deicticCopula} the {evaluativeAdjective} {summaryNoun}.",
+        "range": [
+          7038,
+          7061
+        ],
+        "ruleId": "semantic-thinness",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 7063,
+        "line": 327,
+        "loc": {
+          "end": {
+            "column": 60,
+            "line": 327
+          },
+          "start": {
+            "column": 1,
+            "line": 327
+          }
+        },
+        "message": "Semantic thinness (abstract-metaphor-claim): Catch slogan-like abstract metaphors where an abstract subject performs a physical or spatial action with no concrete referent. Matched template: {audiencePreposition} the {automatedAudience} {audienceActivity}, the {identityArtifact} {linkingVerb} the {artifactRole}.",
+        "range": [
+          7063,
+          7122
+        ],
+        "ruleId": "semantic-thinness",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 7124,
+        "line": 329,
+        "loc": {
+          "end": {
+            "column": 46,
+            "line": 329
+          },
+          "start": {
+            "column": 1,
+            "line": 329
+          }
+        },
+        "message": "Semantic thinness (abstract-metaphor-claim): Catch slogan-like abstract metaphors where an abstract subject performs a physical or spatial action with no concrete referent. Matched template: {audiencePreposition} the {automatedAudience}, the {identityArtifact} {linkingVerb} the {artifactRole}.",
+        "range": [
+          7124,
+          7169
+        ],
+        "ruleId": "semantic-thinness",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 7171,
+        "line": 331,
+        "loc": {
+          "end": {
+            "column": 53,
+            "line": 331
+          },
+          "start": {
+            "column": 1,
+            "line": 331
+          }
+        },
+        "message": "Semantic thinness (abstract-metaphor-claim): Catch slogan-like abstract metaphors where an abstract subject performs a physical or spatial action with no concrete referent. Matched template: {audiencePreposition} the {automatedAudience}, the {identityArtifact} {linkingVerb} the {artifactRole}.",
+        "range": [
+          7171,
+          7223
+        ],
+        "ruleId": "semantic-thinness",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 7225,
+        "line": 333,
+        "loc": {
+          "end": {
+            "column": 44,
+            "line": 333
+          },
+          "start": {
+            "column": 1,
+            "line": 333
+          }
+        },
+        "message": "Semantic thinness (abstract-metaphor-claim): Catch slogan-like abstract metaphors where an abstract subject performs a physical or spatial action with no concrete referent. Matched template: {audiencePreposition} the {automatedAudience}, {identityArtifact} {linkingVerb} the {artifactRole}.",
+        "range": [
+          7225,
+          7268
+        ],
+        "ruleId": "semantic-thinness",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 7270,
+        "line": 335,
+        "loc": {
+          "end": {
+            "column": 28,
+            "line": 335
+          },
+          "start": {
+            "column": 1,
+            "line": 335
+          }
+        },
+        "message": "Demonstrative emphasis found: \"The prompt is the strategy.\". Reduce repeated short emphasis lines.",
+        "range": [
+          7270,
+          7297
         ],
         "ruleId": "demonstrative-emphasis",
         "severity": 2,
@@ -4144,22 +4501,22 @@
       },
       {
         "column": 1,
-        "index": 6636,
-        "line": 299,
+        "index": 7270,
+        "line": 335,
         "loc": {
           "end": {
-            "column": 32,
-            "line": 299
+            "column": 28,
+            "line": 335
           },
           "start": {
             "column": 1,
-            "line": 299
+            "line": 335
           }
         },
-        "message": "Semantic thinness (abstract-metaphor-claim): Catch slogan-like abstract metaphors where an abstract subject performs a physical or spatial action with no concrete referent. Matched template: the {identityArtifact} {linkingVerb} the {artifactRole} now.",
+        "message": "Semantic thinness (abstract-metaphor-claim): Catch slogan-like abstract metaphors where an abstract subject performs a physical or spatial action with no concrete referent. Matched template: the {identityArtifact} {linkingVerb} the {artifactRole}.",
         "range": [
-          6636,
-          6667
+          7270,
+          7297
         ],
         "ruleId": "semantic-thinness",
         "severity": 2,
@@ -4167,22 +4524,344 @@
       },
       {
         "column": 1,
-        "index": 6669,
-        "line": 301,
+        "index": 7299,
+        "line": 337,
         "loc": {
           "end": {
-            "column": 18,
-            "line": 301
+            "column": 31,
+            "line": 337
           },
           "start": {
             "column": 1,
-            "line": 301
+            "line": 337
+          }
+        },
+        "message": "Demonstrative emphasis found: \"The dashboard is the decision.\". Reduce repeated short emphasis lines.",
+        "range": [
+          7299,
+          7329
+        ],
+        "ruleId": "demonstrative-emphasis",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 7299,
+        "line": 337,
+        "loc": {
+          "end": {
+            "column": 31,
+            "line": 337
+          },
+          "start": {
+            "column": 1,
+            "line": 337
+          }
+        },
+        "message": "Semantic thinness (abstract-metaphor-claim): Catch slogan-like abstract metaphors where an abstract subject performs a physical or spatial action with no concrete referent. Matched template: the {identityArtifact} {linkingVerb} the {artifactRole}.",
+        "range": [
+          7299,
+          7329
+        ],
+        "ruleId": "semantic-thinness",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 7331,
+        "line": 339,
+        "loc": {
+          "end": {
+            "column": 30,
+            "line": 339
+          },
+          "start": {
+            "column": 1,
+            "line": 339
+          }
+        },
+        "message": "Semantic thinness (abstract-metaphor-claim): Catch slogan-like abstract metaphors where an abstract subject performs a physical or spatial action with no concrete referent. Matched template: the {identityArtifact} {linkingVerb} the {artifactRole}.",
+        "range": [
+          7331,
+          7360
+        ],
+        "ruleId": "semantic-thinness",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 7362,
+        "line": 341,
+        "loc": {
+          "end": {
+            "column": 33,
+            "line": 341
+          },
+          "start": {
+            "column": 1,
+            "line": 341
+          }
+        },
+        "message": "Demonstrative emphasis found: \"The spreadsheet is the business.\". Reduce repeated short emphasis lines.",
+        "range": [
+          7362,
+          7394
+        ],
+        "ruleId": "demonstrative-emphasis",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 7362,
+        "line": 341,
+        "loc": {
+          "end": {
+            "column": 33,
+            "line": 341
+          },
+          "start": {
+            "column": 1,
+            "line": 341
+          }
+        },
+        "message": "Semantic thinness (abstract-metaphor-claim): Catch slogan-like abstract metaphors where an abstract subject performs a physical or spatial action with no concrete referent. Matched template: the {identityArtifact} {linkingVerb} the {artifactRole}.",
+        "range": [
+          7362,
+          7394
+        ],
+        "ruleId": "semantic-thinness",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 7396,
+        "line": 343,
+        "loc": {
+          "end": {
+            "column": 25,
+            "line": 343
+          },
+          "start": {
+            "column": 1,
+            "line": 343
+          }
+        },
+        "message": "Demonstrative emphasis found: \"The index is the market.\". Reduce repeated short emphasis lines.",
+        "range": [
+          7396,
+          7420
+        ],
+        "ruleId": "demonstrative-emphasis",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 7396,
+        "line": 343,
+        "loc": {
+          "end": {
+            "column": 25,
+            "line": 343
+          },
+          "start": {
+            "column": 1,
+            "line": 343
+          }
+        },
+        "message": "Semantic thinness (abstract-metaphor-claim): Catch slogan-like abstract metaphors where an abstract subject performs a physical or spatial action with no concrete referent. Matched template: the {identityArtifact} {linkingVerb} the {artifactRole}.",
+        "range": [
+          7396,
+          7420
+        ],
+        "ruleId": "semantic-thinness",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 7422,
+        "line": 345,
+        "loc": {
+          "end": {
+            "column": 26,
+            "line": 345
+          },
+          "start": {
+            "column": 1,
+            "line": 345
+          }
+        },
+        "message": "Demonstrative emphasis found: \"The pipeline is the work.\". Reduce repeated short emphasis lines.",
+        "range": [
+          7422,
+          7447
+        ],
+        "ruleId": "demonstrative-emphasis",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 7422,
+        "line": 345,
+        "loc": {
+          "end": {
+            "column": 26,
+            "line": 345
+          },
+          "start": {
+            "column": 1,
+            "line": 345
+          }
+        },
+        "message": "Semantic thinness (abstract-metaphor-claim): Catch slogan-like abstract metaphors where an abstract subject performs a physical or spatial action with no concrete referent. Matched template: the {identityArtifact} {linkingVerb} the {artifactRole}.",
+        "range": [
+          7422,
+          7447
+        ],
+        "ruleId": "semantic-thinness",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 7449,
+        "line": 347,
+        "loc": {
+          "end": {
+            "column": 33,
+            "line": 347
+          },
+          "start": {
+            "column": 1,
+            "line": 347
+          }
+        },
+        "message": "Demonstrative emphasis found: \"The interface is the experience.\". Reduce repeated short emphasis lines.",
+        "range": [
+          7449,
+          7481
+        ],
+        "ruleId": "demonstrative-emphasis",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 7449,
+        "line": 347,
+        "loc": {
+          "end": {
+            "column": 33,
+            "line": 347
+          },
+          "start": {
+            "column": 1,
+            "line": 347
+          }
+        },
+        "message": "Semantic thinness (abstract-metaphor-claim): Catch slogan-like abstract metaphors where an abstract subject performs a physical or spatial action with no concrete referent. Matched template: the {identityArtifact} {linkingVerb} the {artifactRole}.",
+        "range": [
+          7449,
+          7481
+        ],
+        "ruleId": "semantic-thinness",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 7483,
+        "line": 349,
+        "loc": {
+          "end": {
+            "column": 36,
+            "line": 349
+          },
+          "start": {
+            "column": 1,
+            "line": 349
+          }
+        },
+        "message": "Semantic thinness (abstract-metaphor-claim): Catch slogan-like abstract metaphors where an abstract subject performs a physical or spatial action with no concrete referent. Matched template: the {identityArtifact} {linkingVerb} the {artifactRole}.",
+        "range": [
+          7483,
+          7518
+        ],
+        "ruleId": "semantic-thinness",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 7520,
+        "line": 351,
+        "loc": {
+          "end": {
+            "column": 32,
+            "line": 351
+          },
+          "start": {
+            "column": 1,
+            "line": 351
+          }
+        },
+        "message": "Demonstrative emphasis found: \"So the feed is the product now.\". Reduce repeated short emphasis lines.",
+        "range": [
+          7520,
+          7551
+        ],
+        "ruleId": "demonstrative-emphasis",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 7520,
+        "line": 351,
+        "loc": {
+          "end": {
+            "column": 32,
+            "line": 351
+          },
+          "start": {
+            "column": 1,
+            "line": 351
+          }
+        },
+        "message": "Semantic thinness (abstract-metaphor-claim): Catch slogan-like abstract metaphors where an abstract subject performs a physical or spatial action with no concrete referent. Matched template: the {identityArtifact} {linkingVerb} the {artifactRole} now.",
+        "range": [
+          7520,
+          7551
+        ],
+        "ruleId": "semantic-thinness",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 7553,
+        "line": 353,
+        "loc": {
+          "end": {
+            "column": 18,
+            "line": 353
+          },
+          "start": {
+            "column": 1,
+            "line": 353
           }
         },
         "message": "Semantic thinness (deictic-summary): Catch deictic summary pronouncements that point at a supposed lesson, truth, promise, or part without naming the concrete claim. Matched template: {deicticCopula} the {summaryNoun}.",
         "range": [
-          6669,
-          6686
+          7553,
+          7570
         ],
         "ruleId": "semantic-thinness",
         "severity": 2,
@@ -4207,7 +4886,7 @@
             "line": 1
           }
         },
-        "message": "Coleman-Liau is 12.97. Keep it at 12 or lower.",
+        "message": "Coleman-Liau is 13.14. Keep it at 12 or lower.",
         "range": [
           0,
           1
@@ -4230,7 +4909,7 @@
             "line": 1
           }
         },
-        "message": "Flesch Reading Ease is -1486.22. Keep it at 61 or higher.",
+        "message": "Flesch Reading Ease is -1695.31. Keep it at 61 or higher.",
         "range": [
           0,
           1
@@ -4253,7 +4932,7 @@
             "line": 1
           }
         },
-        "message": "Gunning Fog is 619.53. Keep it at 12 or lower.",
+        "message": "Gunning Fog is 702.07. Keep it at 12 or lower.",
         "range": [
           0,
           1
@@ -4355,23 +5034,58 @@
         "type": "lint"
       },
       {
+        "column": 11,
+        "data": {
+          "message": "\"quietly\" used 5 times (2.8 per 1,000 words), above the 2-per-1,000-word error threshold. Cut the filler uses; keep at most about one per 1,000 words.",
+          "padding": {
+            "isAbsolute": false,
+            "range": [
+              9496,
+              9503
+            ],
+            "type": "TextlintRuleErrorPaddingLocation"
+          },
+          "severity": 2
+        },
+        "index": 9496,
+        "line": 299,
+        "loc": {
+          "end": {
+            "column": 18,
+            "line": 299
+          },
+          "start": {
+            "column": 11,
+            "line": 299
+          }
+        },
+        "message": "\"quietly\" used 5 times (2.8 per 1,000 words), above the 2-per-1,000-word error threshold. Cut the filler uses; keep at most about one per 1,000 words.",
+        "range": [
+          9496,
+          9503
+        ],
+        "ruleId": "quietly-overuse",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
         "column": 1,
-        "index": 9140,
-        "line": 287,
+        "index": 10410,
+        "line": 331,
         "loc": {
           "end": {
             "column": 47,
-            "line": 287
+            "line": 331
           },
           "start": {
             "column": 1,
-            "line": 287
+            "line": 331
           }
         },
         "message": "Boilerplate conclusion found: that-is-the-point. Replace the closer with a specific ending.",
         "range": [
-          9140,
-          9186
+          10410,
+          10456
         ],
         "ruleId": "boilerplate-conclusion",
         "severity": 2,

--- a/behavior/golden/textlint-rules-cases-words/approved.meta.json
+++ b/behavior/golden/textlint-rules-cases-words/approved.meta.json
@@ -1,11 +1,11 @@
 {
   "suite": "textlint-rules-cases-words",
   "kind": "approved",
-  "run_id": "2026-07-24T10-31-55.898594Z-04547efb",
-  "run_commit": "ddf8160",
+  "run_id": "2026-07-24T19-55-58.641083Z-04547efb",
+  "run_commit": "51aa56d",
   "working_tree": "dirty",
-  "recorded_at": "2026-07-24T10:31:55.898594Z",
-  "fixture_hash": "sha256:1c8f5544bccd1c9c6926fd5c24ce3f4e0d984f00f39159b4121a57897e8f4dcc",
+  "recorded_at": "2026-07-24T19:55:58.641083Z",
+  "fixture_hash": "sha256:7fa15be4e2dda89655d0c767a8e2958d77d37484cc30d861b89337968e271b47",
   "manifest_hash": "sha256:04547efbb13157ee3d8ef18dda767231fd63d3f9cc27c15317cf28c5f0583e7b",
   "tool_version": "0.1.8",
   "output_schema_version": "1",
@@ -20,8 +20,28 @@
     },
     {
       "path": "behavior/fixtures/textlint-rules/cases/words/no-hits.md",
-      "sha256": "sha256:d348fdcaf4647ffa8b1bf6e0643cdc904dfa957cb47077f98416639440874417"
+      "sha256": "sha256:5b55531b5ce77755ae921348ecbb2af9cd3e9500834eba11d102b8f891dbecbb"
+    },
+    {
+      "path": "behavior/fixtures/textlint-rules/cases/words/quietly-at-rate-boundary.md",
+      "sha256": "sha256:888c7424f362a569c16399ab48402ca089247733463bf0e2de87d97d85527502"
+    },
+    {
+      "path": "behavior/fixtures/textlint-rules/cases/words/quietly-below-minimum.md",
+      "sha256": "sha256:c0bc50749d6875b5baf0dc5364ee3eb941d07aba165882c51805aaf4d15d69e7"
+    },
+    {
+      "path": "behavior/fixtures/textlint-rules/cases/words/quietly-hard-break.md",
+      "sha256": "sha256:4efb15b5dfd0880f3b0224fe49a1fbb9a59e5b2c5d8d2e1c8b9504cf81fd7f54"
+    },
+    {
+      "path": "behavior/fixtures/textlint-rules/cases/words/quietly-overuse.md",
+      "sha256": "sha256:2e06eb0f5db8b402ffe42791b574928fe54343c38fe6d6421451c432f4105a22"
+    },
+    {
+      "path": "behavior/fixtures/textlint-rules/cases/words/quietly-warning-rate.md",
+      "sha256": "sha256:f8c272ff28bab04f94dd69ffa54e1f4f7931231d4d03a645c7efeca5f07b2ced"
     }
   ],
-  "comment": "Normalize fixture paths relative to repository; findings unchanged"
+  "comment": "Use backslash Markdown hard break; reviewed exact source token range."
 }

--- a/behavior/golden/textlint-rules-cases-words/approved.normalized.json
+++ b/behavior/golden/textlint-rules-cases-words/approved.normalized.json
@@ -866,7 +866,7 @@
             "line": 1
           }
         },
-        "message": "Coleman-Liau is 14.35. Keep it at 12 or lower.",
+        "message": "Coleman-Liau is 14.18. Keep it at 12 or lower.",
         "range": [
           0,
           1
@@ -889,7 +889,7 @@
             "line": 1
           }
         },
-        "message": "Flesch Reading Ease is -29.53. Keep it at 61 or higher.",
+        "message": "Flesch Reading Ease is -35.11. Keep it at 61 or higher.",
         "range": [
           0,
           1
@@ -912,13 +912,372 @@
             "line": 1
           }
         },
-        "message": "Gunning Fog is 44.42. Keep it at 12 or lower.",
+        "message": "Gunning Fog is 46.57. Keep it at 12 or lower.",
         "range": [
           0,
           1
         ],
         "ruleId": "gunning-fog",
         "severity": 2,
+        "type": "lint"
+      }
+    ]
+  },
+  {
+    "filePath": "behavior/fixtures/textlint-rules/cases/words/quietly-at-rate-boundary.md",
+    "messages": [
+      {
+        "column": 1,
+        "index": 25,
+        "line": 3,
+        "loc": {
+          "end": {
+            "column": 2,
+            "line": 3
+          },
+          "start": {
+            "column": 1,
+            "line": 3
+          }
+        },
+        "message": "Coleman-Liau is 17.09. Keep it at 12 or lower.",
+        "range": [
+          25,
+          26
+        ],
+        "ruleId": "coleman-liau",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 25,
+        "line": 3,
+        "loc": {
+          "end": {
+            "column": 2,
+            "line": 3
+          },
+          "start": {
+            "column": 1,
+            "line": 3
+          }
+        },
+        "message": "Flesch Reading Ease is -3996.99. Keep it at 61 or higher.",
+        "range": [
+          25,
+          26
+        ],
+        "ruleId": "flesch-kincaid",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 25,
+        "line": 3,
+        "loc": {
+          "end": {
+            "column": 2,
+            "line": 3
+          },
+          "start": {
+            "column": 1,
+            "line": 3
+          }
+        },
+        "message": "Gunning Fog is 1600.1. Keep it at 12 or lower.",
+        "range": [
+          25,
+          26
+        ],
+        "ruleId": "gunning-fog",
+        "severity": 2,
+        "type": "lint"
+      }
+    ]
+  },
+  {
+    "filePath": "behavior/fixtures/textlint-rules/cases/words/quietly-below-minimum.md",
+    "messages": []
+  },
+  {
+    "filePath": "behavior/fixtures/textlint-rules/cases/words/quietly-hard-break.md",
+    "messages": [
+      {
+        "column": 1,
+        "index": 0,
+        "line": 1,
+        "loc": {
+          "end": {
+            "column": 2,
+            "line": 1
+          },
+          "start": {
+            "column": 1,
+            "line": 1
+          }
+        },
+        "message": "Coleman-Liau is 12.41. Keep it at 12 or lower.",
+        "range": [
+          0,
+          1
+        ],
+        "ruleId": "coleman-liau",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 0,
+        "line": 1,
+        "loc": {
+          "end": {
+            "column": 2,
+            "line": 1
+          },
+          "start": {
+            "column": 1,
+            "line": 1
+          }
+        },
+        "message": "Flesch Reading Ease is 48.26. Keep it at 61 or higher.",
+        "range": [
+          0,
+          1
+        ],
+        "ruleId": "flesch-kincaid",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 46,
+        "line": 2,
+        "loc": {
+          "end": {
+            "column": 167,
+            "line": 2
+          },
+          "start": {
+            "column": 1,
+            "line": 2
+          }
+        },
+        "message": "Fragment stack found: The summary quietly changed the subject. The conclusion quietly changed the subject. The sidebar quietly changed the subject. The caption quietly changed the subject. Rewrite the clipped cadence as normal prose.",
+        "range": [
+          46,
+          212
+        ],
+        "ruleId": "fragment-stacking",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 13,
+        "data": {
+          "message": "\"quietly\" used 4 times (129 per 1,000 words), above the 2-per-1,000-word error threshold. Cut the filler uses; keep at most about one per 1,000 words.",
+          "padding": {
+            "isAbsolute": false,
+            "range": [
+              58,
+              65
+            ],
+            "type": "TextlintRuleErrorPaddingLocation"
+          },
+          "severity": 2
+        },
+        "index": 58,
+        "line": 2,
+        "loc": {
+          "end": {
+            "column": 20,
+            "line": 2
+          },
+          "start": {
+            "column": 13,
+            "line": 2
+          }
+        },
+        "message": "\"quietly\" used 4 times (129 per 1,000 words), above the 2-per-1,000-word error threshold. Cut the filler uses; keep at most about one per 1,000 words.",
+        "range": [
+          58,
+          65
+        ],
+        "ruleId": "quietly-overuse",
+        "severity": 2,
+        "type": "lint"
+      }
+    ]
+  },
+  {
+    "filePath": "behavior/fixtures/textlint-rules/cases/words/quietly-overuse.md",
+    "messages": [
+      {
+        "column": 1,
+        "index": 0,
+        "line": 1,
+        "loc": {
+          "end": {
+            "column": 2,
+            "line": 1
+          },
+          "start": {
+            "column": 1,
+            "line": 1
+          }
+        },
+        "message": "Flesch Reading Ease is 46.03. Keep it at 61 or higher.",
+        "range": [
+          0,
+          1
+        ],
+        "ruleId": "flesch-kincaid",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 12,
+        "data": {
+          "message": "\"quietly\" used 10 times (131.6 per 1,000 words), above the 2-per-1,000-word error threshold. Cut the filler uses; keep at most about one per 1,000 words.",
+          "padding": {
+            "isAbsolute": false,
+            "range": [
+              11,
+              18
+            ],
+            "type": "TextlintRuleErrorPaddingLocation"
+          },
+          "severity": 2
+        },
+        "index": 11,
+        "line": 1,
+        "loc": {
+          "end": {
+            "column": 19,
+            "line": 1
+          },
+          "start": {
+            "column": 12,
+            "line": 1
+          }
+        },
+        "message": "\"quietly\" used 10 times (131.6 per 1,000 words), above the 2-per-1,000-word error threshold. Cut the filler uses; keep at most about one per 1,000 words.",
+        "range": [
+          11,
+          18
+        ],
+        "ruleId": "quietly-overuse",
+        "severity": 2,
+        "type": "lint"
+      }
+    ]
+  },
+  {
+    "filePath": "behavior/fixtures/textlint-rules/cases/words/quietly-warning-rate.md",
+    "messages": [
+      {
+        "column": 1,
+        "index": 25,
+        "line": 3,
+        "loc": {
+          "end": {
+            "column": 2,
+            "line": 3
+          },
+          "start": {
+            "column": 1,
+            "line": 3
+          }
+        },
+        "message": "Coleman-Liau is 17.09. Keep it at 12 or lower.",
+        "range": [
+          25,
+          26
+        ],
+        "ruleId": "coleman-liau",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 25,
+        "line": 3,
+        "loc": {
+          "end": {
+            "column": 2,
+            "line": 3
+          },
+          "start": {
+            "column": 1,
+            "line": 3
+          }
+        },
+        "message": "Flesch Reading Ease is -2626.74. Keep it at 61 or higher.",
+        "range": [
+          25,
+          26
+        ],
+        "ruleId": "flesch-kincaid",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 25,
+        "line": 3,
+        "loc": {
+          "end": {
+            "column": 2,
+            "line": 3
+          },
+          "start": {
+            "column": 1,
+            "line": 3
+          }
+        },
+        "message": "Gunning Fog is 1060.15. Keep it at 12 or lower.",
+        "range": [
+          25,
+          26
+        ],
+        "ruleId": "gunning-fog",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 12,
+        "data": {
+          "message": "\"quietly\" used 4 times (1.5 per 1,000 words), above the 1-per-1,000-word warning threshold. Cut the filler uses; keep at most about one per 1,000 words.",
+          "padding": {
+            "isAbsolute": false,
+            "range": [
+              214,
+              221
+            ],
+            "type": "TextlintRuleErrorPaddingLocation"
+          },
+          "severity": 1
+        },
+        "index": 214,
+        "line": 9,
+        "loc": {
+          "end": {
+            "column": 19,
+            "line": 9
+          },
+          "start": {
+            "column": 12,
+            "line": 9
+          }
+        },
+        "message": "\"quietly\" used 4 times (1.5 per 1,000 words), above the 1-per-1,000-word warning threshold. Cut the filler uses; keep at most about one per 1,000 words.",
+        "range": [
+          214,
+          221
+        ],
+        "ruleId": "quietly-overuse",
+        "severity": 1,
         "type": "lint"
       }
     ]

--- a/behavior/golden/textlint-rules-corpus-editorial-style/approved.meta.json
+++ b/behavior/golden/textlint-rules-corpus-editorial-style/approved.meta.json
@@ -1,19 +1,19 @@
 {
   "suite": "textlint-rules-corpus-editorial-style",
   "kind": "approved",
-  "run_id": "2026-07-24T10-32-10.753912Z-04547efb",
-  "run_commit": "ddf8160",
+  "run_id": "2026-07-24T19-13-18.686702Z-04547efb",
+  "run_commit": "51aa56d",
   "working_tree": "dirty",
-  "recorded_at": "2026-07-24T10:32:10.753912Z",
-  "fixture_hash": "sha256:1c16b69b1fc2e8c1d5611db5ab2cb07de277db4b66e90323021e3227b95ebeef",
+  "recorded_at": "2026-07-24T19:13:18.686702Z",
+  "fixture_hash": "sha256:4a6228dd8659fef2510493427d2d94533394a8ebfae59fccf13d36fe2b9da077",
   "manifest_hash": "sha256:04547efbb13157ee3d8ef18dda767231fd63d3f9cc27c15317cf28c5f0583e7b",
   "tool_version": "0.1.8",
   "output_schema_version": "1",
   "fixtures": [
     {
       "path": "behavior/fixtures/textlint-rules/corpus/editorial-style.md",
-      "sha256": "sha256:38c563534f586173814ad27da58345e231d0e19342defb177a93ae97a64a56e6"
+      "sha256": "sha256:e647a9932b619c833fcfca01a22c9e311285b785112ad04986f6fb54059e0108"
     }
   ],
-  "comment": "Normalize fixture paths relative to repository; findings unchanged"
+  "comment": "Reviewed vague-change templates, quietly density, and corrected document source offsets."
 }

--- a/behavior/golden/textlint-rules-corpus-editorial-style/approved.normalized.json
+++ b/behavior/golden/textlint-rules-corpus-editorial-style/approved.normalized.json
@@ -4,22 +4,22 @@
     "messages": [
       {
         "column": 1,
-        "index": 0,
-        "line": 1,
+        "index": 26,
+        "line": 3,
         "loc": {
           "end": {
             "column": 2,
-            "line": 1
+            "line": 3
           },
           "start": {
             "column": 1,
-            "line": 1
+            "line": 3
           }
         },
-        "message": "Coleman-Liau is 13.3. Keep it at 12 or lower.",
+        "message": "Coleman-Liau is 13. Keep it at 12 or lower.",
         "range": [
-          0,
-          1
+          26,
+          27
         ],
         "ruleId": "coleman-liau",
         "severity": 2,
@@ -27,22 +27,22 @@
       },
       {
         "column": 1,
-        "index": 0,
-        "line": 1,
+        "index": 26,
+        "line": 3,
         "loc": {
           "end": {
             "column": 2,
-            "line": 1
+            "line": 3
           },
           "start": {
             "column": 1,
-            "line": 1
+            "line": 3
           }
         },
-        "message": "Flesch Reading Ease is 42.34. Keep it at 61 or higher.",
+        "message": "Flesch Reading Ease is 43.77. Keep it at 61 or higher.",
         "range": [
-          0,
-          1
+          26,
+          27
         ],
         "ruleId": "flesch-kincaid",
         "severity": 2,
@@ -50,22 +50,22 @@
       },
       {
         "column": 1,
-        "index": 0,
-        "line": 1,
+        "index": 26,
+        "line": 3,
         "loc": {
           "end": {
             "column": 2,
-            "line": 1
+            "line": 3
           },
           "start": {
             "column": 1,
-            "line": 1
+            "line": 3
           }
         },
-        "message": "Gunning Fog is 14.22. Keep it at 12 or lower.",
+        "message": "Gunning Fog is 13.64. Keep it at 12 or lower.",
         "range": [
-          0,
-          1
+          26,
+          27
         ],
         "ruleId": "gunning-fog",
         "severity": 2,
@@ -9061,6 +9061,41 @@
           30653
         ],
         "ruleId": "negation-reframe",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 112,
+        "data": {
+          "message": "\"quietly\" used 14 times (2.8 per 1,000 words), above the 2-per-1,000-word error threshold. Cut the filler uses; keep at most about one per 1,000 words.",
+          "padding": {
+            "isAbsolute": false,
+            "range": [
+              30791,
+              30798
+            ],
+            "type": "TextlintRuleErrorPaddingLocation"
+          },
+          "severity": 2
+        },
+        "index": 30791,
+        "line": 809,
+        "loc": {
+          "end": {
+            "column": 119,
+            "line": 809
+          },
+          "start": {
+            "column": 112,
+            "line": 809
+          }
+        },
+        "message": "\"quietly\" used 14 times (2.8 per 1,000 words), above the 2-per-1,000-word error threshold. Cut the filler uses; keep at most about one per 1,000 words.",
+        "range": [
+          30791,
+          30798
+        ],
+        "ruleId": "quietly-overuse",
         "severity": 2,
         "type": "lint"
       }

--- a/behavior/golden/textlint-rules-corpus-engineering-review/approved.meta.json
+++ b/behavior/golden/textlint-rules-corpus-engineering-review/approved.meta.json
@@ -1,19 +1,19 @@
 {
   "suite": "textlint-rules-corpus-engineering-review",
   "kind": "approved",
-  "run_id": "2026-07-24T14-55-24.369937Z-04547efb",
-  "run_commit": "88996f4",
+  "run_id": "2026-07-24T19-13-28.121671Z-04547efb",
+  "run_commit": "51aa56d",
   "working_tree": "dirty",
-  "recorded_at": "2026-07-24T14:55:24.369937Z",
-  "fixture_hash": "sha256:f7253355ba97e0677795b4e1c3727d09062244d496ec56c04d7026e532734aee",
+  "recorded_at": "2026-07-24T19:13:28.121671Z",
+  "fixture_hash": "sha256:07c79aa909b728907c7ea1c6bf649c45b0ea14d74695abc7a9ff732b0f237867",
   "manifest_hash": "sha256:04547efbb13157ee3d8ef18dda767231fd63d3f9cc27c15317cf28c5f0583e7b",
   "tool_version": "0.1.8",
   "output_schema_version": "1",
   "fixtures": [
     {
       "path": "behavior/fixtures/textlint-rules/corpus/engineering-review.md",
-      "sha256": "sha256:91a88819a89c7866df076116a77ecd1dfaa4a6afcb7c8a0ab34d9f06cabc4be9"
+      "sha256": "sha256:5736692e976b2d333ea07e9662ea66bf241c8057022e46b2318fca559b7dee43"
     }
   ],
-  "comment": "Add coherent deictic evaluative signposting and concrete continuation coverage"
+  "comment": "Reviewed vague-change templates, quietly density, and corrected document source offsets."
 }

--- a/behavior/golden/textlint-rules-corpus-engineering-review/approved.normalized.json
+++ b/behavior/golden/textlint-rules-corpus-engineering-review/approved.normalized.json
@@ -4,47 +4,24 @@
     "messages": [
       {
         "column": 1,
-        "index": 0,
-        "line": 1,
+        "index": 28,
+        "line": 3,
         "loc": {
           "end": {
             "column": 2,
-            "line": 1
+            "line": 3
           },
           "start": {
             "column": 1,
-            "line": 1
+            "line": 3
           }
         },
-        "message": "Flesch Reading Ease is 55.88. Keep it at 61 or higher.",
+        "message": "Flesch Reading Ease is 57.5. Keep it at 61 or higher.",
         "range": [
-          0,
-          1
+          28,
+          29
         ],
         "ruleId": "flesch-kincaid",
-        "severity": 2,
-        "type": "lint"
-      },
-      {
-        "column": 1,
-        "index": 0,
-        "line": 1,
-        "loc": {
-          "end": {
-            "column": 2,
-            "line": 1
-          },
-          "start": {
-            "column": 1,
-            "line": 1
-          }
-        },
-        "message": "Gunning Fog is 12.01. Keep it at 12 or lower.",
-        "range": [
-          0,
-          1
-        ],
-        "ruleId": "gunning-fog",
         "severity": 2,
         "type": "lint"
       },
@@ -4416,6 +4393,41 @@
         ],
         "ruleId": "negation-reframe",
         "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 72,
+        "data": {
+          "message": "\"quietly\" used 12 times (1.3 per 1,000 words), above the 1-per-1,000-word warning threshold. Cut the filler uses; keep at most about one per 1,000 words.",
+          "padding": {
+            "isAbsolute": false,
+            "range": [
+              19314,
+              19321
+            ],
+            "type": "TextlintRuleErrorPaddingLocation"
+          },
+          "severity": 1
+        },
+        "index": 19314,
+        "line": 475,
+        "loc": {
+          "end": {
+            "column": 79,
+            "line": 475
+          },
+          "start": {
+            "column": 72,
+            "line": 475
+          }
+        },
+        "message": "\"quietly\" used 12 times (1.3 per 1,000 words), above the 1-per-1,000-word warning threshold. Cut the filler uses; keep at most about one per 1,000 words.",
+        "range": [
+          19314,
+          19321
+        ],
+        "ruleId": "quietly-overuse",
+        "severity": 1,
         "type": "lint"
       },
       {
@@ -10832,6 +10844,742 @@
           51253
         ],
         "ruleId": "generic-signposting",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 78,
+        "index": 52229,
+        "line": 1125,
+        "loc": {
+          "end": {
+            "column": 109,
+            "line": 1125
+          },
+          "start": {
+            "column": 78,
+            "line": 1125
+          }
+        },
+        "message": "Semantic thinness (something-shifted): Catch vague change declarations that say something shifted, changed, moved, or crossed a line without naming the concrete change. Matched template: {diffuseSubject} {progressiveAuxiliary} {weakMannerAdverb} {progressiveChange}.",
+        "range": [
+          52229,
+          52260
+        ],
+        "ruleId": "semantic-thinness",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 110,
+        "index": 52261,
+        "line": 1125,
+        "loc": {
+          "end": {
+            "column": 142,
+            "line": 1125
+          },
+          "start": {
+            "column": 110,
+            "line": 1125
+          }
+        },
+        "message": "Semantic thinness (something-shifted): Catch vague change declarations that say something shifted, changed, moved, or crossed a line without naming the concrete change. Matched template: {diffuseSubject} {progressiveAuxiliary} {weakMannerAdverb} {progressiveChange}.",
+        "range": [
+          52261,
+          52293
+        ],
+        "ruleId": "semantic-thinness",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 143,
+        "index": 52294,
+        "line": 1125,
+        "loc": {
+          "end": {
+            "column": 172,
+            "line": 1125
+          },
+          "start": {
+            "column": 143,
+            "line": 1125
+          }
+        },
+        "message": "Semantic thinness (something-shifted): Catch vague change declarations that say something shifted, changed, moved, or crossed a line without naming the concrete change. Matched template: {diffuseSubject} {progressiveAuxiliary} {weakMannerAdverb} {progressiveChange}.",
+        "range": [
+          52294,
+          52323
+        ],
+        "ruleId": "semantic-thinness",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 44,
+        "index": 52368,
+        "line": 1127,
+        "loc": {
+          "end": {
+            "column": 77,
+            "line": 1127
+          },
+          "start": {
+            "column": 44,
+            "line": 1127
+          }
+        },
+        "message": "Semantic thinness (something-shifted): Catch vague change declarations that say something shifted, changed, moved, or crossed a line without naming the concrete change. Matched template: {diffuseSubject} {progressiveAuxiliary} {weakMannerAdverb} {progressiveChange}.",
+        "range": [
+          52368,
+          52401
+        ],
+        "ruleId": "semantic-thinness",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 78,
+        "index": 52402,
+        "line": 1127,
+        "loc": {
+          "end": {
+            "column": 114,
+            "line": 1127
+          },
+          "start": {
+            "column": 78,
+            "line": 1127
+          }
+        },
+        "message": "Semantic thinness (something-shifted): Catch vague change declarations that say something shifted, changed, moved, or crossed a line without naming the concrete change. Matched template: {diffuseSubject} {progressiveAuxiliary} {weakMannerAdverb} {progressiveChange}.",
+        "range": [
+          52402,
+          52438
+        ],
+        "ruleId": "semantic-thinness",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 115,
+        "index": 52439,
+        "line": 1127,
+        "loc": {
+          "end": {
+            "column": 159,
+            "line": 1127
+          },
+          "start": {
+            "column": 115,
+            "line": 1127
+          }
+        },
+        "message": "Semantic thinness (something-shifted): Catch vague change declarations that say something shifted, changed, moved, or crossed a line without naming the concrete change. Matched template: {diffuseSubject} {progressiveAuxiliary} {weakMannerAdverb} {progressiveChange}.",
+        "range": [
+          52439,
+          52483
+        ],
+        "ruleId": "semantic-thinness",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 72,
+        "index": 52556,
+        "line": 1129,
+        "loc": {
+          "end": {
+            "column": 104,
+            "line": 1129
+          },
+          "start": {
+            "column": 72,
+            "line": 1129
+          }
+        },
+        "message": "Semantic thinness (something-shifted): Catch vague change declarations that say something shifted, changed, moved, or crossed a line without naming the concrete change. Matched template: {deicticSubject} {weakMannerAdverb} {emptyChangeObject}.",
+        "range": [
+          52556,
+          52588
+        ],
+        "ruleId": "semantic-thinness",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 105,
+        "index": 52589,
+        "line": 1129,
+        "loc": {
+          "end": {
+            "column": 137,
+            "line": 1129
+          },
+          "start": {
+            "column": 105,
+            "line": 1129
+          }
+        },
+        "message": "Semantic thinness (something-shifted): Catch vague change declarations that say something shifted, changed, moved, or crossed a line without naming the concrete change. Matched template: {deicticSubject} {weakMannerAdverb} {emptyChangeObject}.",
+        "range": [
+          52589,
+          52621
+        ],
+        "ruleId": "semantic-thinness",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 85,
+        "index": 52707,
+        "line": 1131,
+        "loc": {
+          "end": {
+            "column": 111,
+            "line": 1131
+          },
+          "start": {
+            "column": 85,
+            "line": 1131
+          }
+        },
+        "message": "Semantic thinness (something-shifted): Catch vague change declarations that say something shifted, changed, moved, or crossed a line without naming the concrete change. Matched template: {shiftDeterminer} {shiftModifier} shift {emptyShiftPredicate}.",
+        "range": [
+          52707,
+          52733
+        ],
+        "ruleId": "semantic-thinness",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 85,
+        "index": 52707,
+        "line": 1131,
+        "loc": {
+          "end": {
+            "column": 208,
+            "line": 1131
+          },
+          "start": {
+            "column": 85,
+            "line": 1131
+          }
+        },
+        "message": "Flat action cadence: 4 adjacent short simple sentences use subject-action beats (shift). Vary the rhythm or add causal/sensory development.",
+        "range": [
+          52707,
+          52830
+        ],
+        "ruleId": "flat-action-cadence",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 112,
+        "index": 52734,
+        "line": 1131,
+        "loc": {
+          "end": {
+            "column": 142,
+            "line": 1131
+          },
+          "start": {
+            "column": 112,
+            "line": 1131
+          }
+        },
+        "message": "Semantic thinness (something-shifted): Catch vague change declarations that say something shifted, changed, moved, or crossed a line without naming the concrete change. Matched template: {shiftDeterminer} {shiftModifier} shift {emptyShiftPredicate}.",
+        "range": [
+          52734,
+          52764
+        ],
+        "ruleId": "semantic-thinness",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 143,
+        "index": 52765,
+        "line": 1131,
+        "loc": {
+          "end": {
+            "column": 172,
+            "line": 1131
+          },
+          "start": {
+            "column": 143,
+            "line": 1131
+          }
+        },
+        "message": "Semantic thinness (something-shifted): Catch vague change declarations that say something shifted, changed, moved, or crossed a line without naming the concrete change. Matched template: {shiftDeterminer} {shiftModifier} shift {emptyShiftPredicate}.",
+        "range": [
+          52765,
+          52794
+        ],
+        "ruleId": "semantic-thinness",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 173,
+        "index": 52795,
+        "line": 1131,
+        "loc": {
+          "end": {
+            "column": 208,
+            "line": 1131
+          },
+          "start": {
+            "column": 173,
+            "line": 1131
+          }
+        },
+        "message": "Semantic thinness (something-shifted): Catch vague change declarations that say something shifted, changed, moved, or crossed a line without naming the concrete change. Matched template: {shiftDeterminer} {shiftModifier} shift {emptyShiftPredicate}.",
+        "range": [
+          52795,
+          52830
+        ],
+        "ruleId": "semantic-thinness",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 46,
+        "index": 52877,
+        "line": 1133,
+        "loc": {
+          "end": {
+            "column": 82,
+            "line": 1133
+          },
+          "start": {
+            "column": 46,
+            "line": 1133
+          }
+        },
+        "message": "Generic signposting found: the-important-shift-is. Replace the frame with the concrete claim.",
+        "range": [
+          52877,
+          52913
+        ],
+        "ruleId": "generic-signposting",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 46,
+        "index": 52877,
+        "line": 1133,
+        "loc": {
+          "end": {
+            "column": 82,
+            "line": 1133
+          },
+          "start": {
+            "column": 46,
+            "line": 1133
+          }
+        },
+        "message": "Semantic thinness (something-shifted): Catch vague change declarations that say something shifted, changed, moved, or crossed a line without naming the concrete change. Matched template: {shiftDeterminer} {shiftModifier} shift {emptyShiftPredicate}.",
+        "range": [
+          52877,
+          52913
+        ],
+        "ruleId": "semantic-thinness",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 46,
+        "index": 52877,
+        "line": 1133,
+        "loc": {
+          "end": {
+            "column": 192,
+            "line": 1133
+          },
+          "start": {
+            "column": 46,
+            "line": 1133
+          }
+        },
+        "message": "Flat action cadence: 4 adjacent short simple sentences use subject-action beats (shift). Vary the rhythm or add causal/sensory development.",
+        "range": [
+          52877,
+          53023
+        ],
+        "ruleId": "flat-action-cadence",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 83,
+        "index": 52914,
+        "line": 1133,
+        "loc": {
+          "end": {
+            "column": 123,
+            "line": 1133
+          },
+          "start": {
+            "column": 83,
+            "line": 1133
+          }
+        },
+        "message": "Semantic thinness (something-shifted): Catch vague change declarations that say something shifted, changed, moved, or crossed a line without naming the concrete change. Matched template: {shiftDeterminer} {shiftModifier} shift {emptyShiftPredicate}.",
+        "range": [
+          52914,
+          52954
+        ],
+        "ruleId": "semantic-thinness",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 124,
+        "index": 52955,
+        "line": 1133,
+        "loc": {
+          "end": {
+            "column": 153,
+            "line": 1133
+          },
+          "start": {
+            "column": 124,
+            "line": 1133
+          }
+        },
+        "message": "Semantic thinness (something-shifted): Catch vague change declarations that say something shifted, changed, moved, or crossed a line without naming the concrete change. Matched template: {shiftDeterminer} {shiftModifier} shift {emptyShiftPredicate}.",
+        "range": [
+          52955,
+          52984
+        ],
+        "ruleId": "semantic-thinness",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 154,
+        "index": 52985,
+        "line": 1133,
+        "loc": {
+          "end": {
+            "column": 192,
+            "line": 1133
+          },
+          "start": {
+            "column": 154,
+            "line": 1133
+          }
+        },
+        "message": "Semantic thinness (something-shifted): Catch vague change declarations that say something shifted, changed, moved, or crossed a line without naming the concrete change. Matched template: {shiftDeterminer} {shiftModifier} shift {emptyShiftPredicate}.",
+        "range": [
+          52985,
+          53023
+        ],
+        "ruleId": "semantic-thinness",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 65,
+        "index": 53089,
+        "line": 1135,
+        "loc": {
+          "end": {
+            "column": 92,
+            "line": 1135
+          },
+          "start": {
+            "column": 65,
+            "line": 1135
+          }
+        },
+        "message": "Semantic thinness (something-shifted): Catch vague change declarations that say something shifted, changed, moved, or crossed a line without naming the concrete change. Matched template: {deicticSubject} {signalVerb} {shiftDeterminer} {shiftModifier} shift.",
+        "range": [
+          53089,
+          53116
+        ],
+        "ruleId": "semantic-thinness",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 65,
+        "index": 53089,
+        "line": 1135,
+        "loc": {
+          "end": {
+            "column": 189,
+            "line": 1135
+          },
+          "start": {
+            "column": 65,
+            "line": 1135
+          }
+        },
+        "message": "Flat action cadence: 4 adjacent short simple sentences use subject-action beats (shift). Vary the rhythm or add causal/sensory development.",
+        "range": [
+          53089,
+          53213
+        ],
+        "ruleId": "flat-action-cadence",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 93,
+        "index": 53117,
+        "line": 1135,
+        "loc": {
+          "end": {
+            "column": 122,
+            "line": 1135
+          },
+          "start": {
+            "column": 93,
+            "line": 1135
+          }
+        },
+        "message": "Semantic thinness (something-shifted): Catch vague change declarations that say something shifted, changed, moved, or crossed a line without naming the concrete change. Matched template: {deicticSubject} {signalVerb} {shiftDeterminer} {shiftModifier} shift.",
+        "range": [
+          53117,
+          53146
+        ],
+        "ruleId": "semantic-thinness",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 98,
+        "index": 53122,
+        "line": 1135,
+        "loc": {
+          "end": {
+            "column": 121,
+            "line": 1135
+          },
+          "start": {
+            "column": 98,
+            "line": 1135
+          }
+        },
+        "message": "Cliche found: \"signals a seismic shift\". Replace it with specific wording.",
+        "range": [
+          53122,
+          53145
+        ],
+        "ruleId": "cliches",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 123,
+        "index": 53147,
+        "line": 1135,
+        "loc": {
+          "end": {
+            "column": 158,
+            "line": 1135
+          },
+          "start": {
+            "column": 123,
+            "line": 1135
+          }
+        },
+        "message": "Semantic thinness (something-shifted): Catch vague change declarations that say something shifted, changed, moved, or crossed a line without naming the concrete change. Matched template: {deicticSubject} {signalVerb} {shiftDeterminer} {shiftModifier} shift.",
+        "range": [
+          53147,
+          53182
+        ],
+        "ruleId": "semantic-thinness",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 159,
+        "index": 53183,
+        "line": 1135,
+        "loc": {
+          "end": {
+            "column": 189,
+            "line": 1135
+          },
+          "start": {
+            "column": 159,
+            "line": 1135
+          }
+        },
+        "message": "Semantic thinness (something-shifted): Catch vague change declarations that say something shifted, changed, moved, or crossed a line without naming the concrete change. Matched template: {deicticSubject} {signalVerb} {shiftDeterminer} {shiftModifier} shift.",
+        "range": [
+          53183,
+          53213
+        ],
+        "ruleId": "semantic-thinness",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 88,
+        "index": 53302,
+        "line": 1137,
+        "loc": {
+          "end": {
+            "column": 116,
+            "line": 1137
+          },
+          "start": {
+            "column": 88,
+            "line": 1137
+          }
+        },
+        "message": "Semantic thinness (something-shifted): Catch vague change declarations that say something shifted, changed, moved, or crossed a line without naming the concrete change. Matched template: {diffuseSubject} {weakMannerAdverb} {finiteChange}.",
+        "range": [
+          53302,
+          53330
+        ],
+        "ruleId": "semantic-thinness",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 117,
+        "index": 53331,
+        "line": 1137,
+        "loc": {
+          "end": {
+            "column": 144,
+            "line": 1137
+          },
+          "start": {
+            "column": 117,
+            "line": 1137
+          }
+        },
+        "message": "Semantic thinness (something-shifted): Catch vague change declarations that say something shifted, changed, moved, or crossed a line without naming the concrete change. Matched template: {diffuseSubject} {weakMannerAdverb} {finiteChange}.",
+        "range": [
+          53331,
+          53358
+        ],
+        "ruleId": "semantic-thinness",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 145,
+        "index": 53359,
+        "line": 1137,
+        "loc": {
+          "end": {
+            "column": 179,
+            "line": 1137
+          },
+          "start": {
+            "column": 145,
+            "line": 1137
+          }
+        },
+        "message": "Semantic thinness (something-shifted): Catch vague change declarations that say something shifted, changed, moved, or crossed a line without naming the concrete change. Matched template: {diffuseSubject} {progressiveAuxiliary} {weakMannerAdverb} {progressiveChange}.",
+        "range": [
+          53359,
+          53393
+        ],
+        "ruleId": "semantic-thinness",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 67,
+        "index": 53461,
+        "line": 1139,
+        "loc": {
+          "end": {
+            "column": 100,
+            "line": 1139
+          },
+          "start": {
+            "column": 67,
+            "line": 1139
+          }
+        },
+        "message": "Semantic thinness (something-shifted): Catch vague change declarations that say something shifted, changed, moved, or crossed a line without naming the concrete change. Matched template: {diffuseSubject} {perfectAuxiliary} {weakMannerAdverb} {pastChange}.",
+        "range": [
+          53461,
+          53494
+        ],
+        "ruleId": "semantic-thinness",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 101,
+        "index": 53495,
+        "line": 1139,
+        "loc": {
+          "end": {
+            "column": 131,
+            "line": 1139
+          },
+          "start": {
+            "column": 101,
+            "line": 1139
+          }
+        },
+        "message": "Semantic thinness (something-shifted): Catch vague change declarations that say something shifted, changed, moved, or crossed a line without naming the concrete change. Matched template: {diffuseSubject} {perfectAuxiliary} {weakMannerAdverb} {pastChange}.",
+        "range": [
+          53495,
+          53525
+        ],
+        "ruleId": "semantic-thinness",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 132,
+        "index": 53526,
+        "line": 1139,
+        "loc": {
+          "end": {
+            "column": 159,
+            "line": 1139
+          },
+          "start": {
+            "column": 132,
+            "line": 1139
+          }
+        },
+        "message": "Semantic thinness (something-shifted): Catch vague change declarations that say something shifted, changed, moved, or crossed a line without naming the concrete change. Matched template: {diffuseSubject} {finiteChange} {weakMannerAdverb}.",
+        "range": [
+          53526,
+          53553
+        ],
+        "ruleId": "semantic-thinness",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 50,
+        "index": 54648,
+        "line": 1151,
+        "loc": {
+          "end": {
+            "column": 198,
+            "line": 1151
+          },
+          "start": {
+            "column": 50,
+            "line": 1151
+          }
+        },
+        "message": "Flat action cadence: 3 adjacent short simple sentences use subject-action beats (shift). Vary the rhythm or add causal/sensory development.",
+        "range": [
+          54648,
+          54796
+        ],
+        "ruleId": "flat-action-cadence",
         "severity": 2,
         "type": "lint"
       }

--- a/behavior/golden/textlint-rules-corpus-health-and-parenting/approved.meta.json
+++ b/behavior/golden/textlint-rules-corpus-health-and-parenting/approved.meta.json
@@ -1,10 +1,10 @@
 {
   "suite": "textlint-rules-corpus-health-and-parenting",
   "kind": "approved",
-  "run_id": "2026-07-24T10-32-26.577383Z-04547efb",
-  "run_commit": "ddf8160",
+  "run_id": "2026-07-24T19-13-32.781287Z-04547efb",
+  "run_commit": "51aa56d",
   "working_tree": "dirty",
-  "recorded_at": "2026-07-24T10:32:26.577383Z",
+  "recorded_at": "2026-07-24T19:13:32.781287Z",
   "fixture_hash": "sha256:3d2a869b3248700accefd17d370ada336d1bb00c3443b39d27eca67ff6d9971f",
   "manifest_hash": "sha256:04547efbb13157ee3d8ef18dda767231fd63d3f9cc27c15317cf28c5f0583e7b",
   "tool_version": "0.1.8",
@@ -15,5 +15,5 @@
       "sha256": "sha256:9175fc7677af80361699b4337516a78653595f6e73e2ef18a9fd585b946e73eb"
     }
   ],
-  "comment": "Normalize fixture paths relative to repository; findings unchanged"
+  "comment": "Reviewed vague-change templates, quietly density, and corrected document source offsets."
 }

--- a/behavior/golden/textlint-rules-corpus-health-and-parenting/approved.normalized.json
+++ b/behavior/golden/textlint-rules-corpus-health-and-parenting/approved.normalized.json
@@ -4,22 +4,22 @@
     "messages": [
       {
         "column": 1,
-        "index": 0,
-        "line": 1,
+        "index": 34,
+        "line": 3,
         "loc": {
           "end": {
             "column": 2,
-            "line": 1
+            "line": 3
           },
           "start": {
             "column": 1,
-            "line": 1
+            "line": 3
           }
         },
         "message": "Coleman-Liau is 12.02. Keep it at 12 or lower.",
         "range": [
-          0,
-          1
+          34,
+          35
         ],
         "ruleId": "coleman-liau",
         "severity": 2,
@@ -27,22 +27,22 @@
       },
       {
         "column": 1,
-        "index": 0,
-        "line": 1,
+        "index": 34,
+        "line": 3,
         "loc": {
           "end": {
             "column": 2,
-            "line": 1
+            "line": 3
           },
           "start": {
             "column": 1,
-            "line": 1
+            "line": 3
           }
         },
         "message": "Flesch Reading Ease is 37.47. Keep it at 61 or higher.",
         "range": [
-          0,
-          1
+          34,
+          35
         ],
         "ruleId": "flesch-kincaid",
         "severity": 2,
@@ -50,22 +50,22 @@
       },
       {
         "column": 1,
-        "index": 0,
-        "line": 1,
+        "index": 34,
+        "line": 3,
         "loc": {
           "end": {
             "column": 2,
-            "line": 1
+            "line": 3
           },
           "start": {
             "column": 1,
-            "line": 1
+            "line": 3
           }
         },
         "message": "Gunning Fog is 16.66. Keep it at 12 or lower.",
         "range": [
-          0,
-          1
+          34,
+          35
         ],
         "ruleId": "gunning-fog",
         "severity": 2,

--- a/behavior/golden/textlint-rules-corpus-linkedin-ai-search/approved.meta.json
+++ b/behavior/golden/textlint-rules-corpus-linkedin-ai-search/approved.meta.json
@@ -1,10 +1,10 @@
 {
   "suite": "textlint-rules-corpus-linkedin-ai-search",
   "kind": "approved",
-  "run_id": "2026-07-24T10-32-30.098081Z-04547efb",
-  "run_commit": "ddf8160",
+  "run_id": "2026-07-24T19-13-35.451906Z-04547efb",
+  "run_commit": "51aa56d",
   "working_tree": "dirty",
-  "recorded_at": "2026-07-24T10:32:30.098081Z",
+  "recorded_at": "2026-07-24T19:13:35.451906Z",
   "fixture_hash": "sha256:854be6a2902cdc6e27765ecb214e039ad58c5d2043d9ccba927cff3ada1f08ff",
   "manifest_hash": "sha256:04547efbb13157ee3d8ef18dda767231fd63d3f9cc27c15317cf28c5f0583e7b",
   "tool_version": "0.1.8",
@@ -15,5 +15,5 @@
       "sha256": "sha256:abece90cf50d4b2462e3df65e9bf1187e29a98e49d31cf8fc93ef590a2776a5c"
     }
   ],
-  "comment": "Normalize fixture paths relative to repository; findings unchanged"
+  "comment": "Reviewed vague-change templates, quietly density, and corrected document source offsets."
 }

--- a/behavior/golden/textlint-rules-corpus-linkedin-ai-search/approved.normalized.json
+++ b/behavior/golden/textlint-rules-corpus-linkedin-ai-search/approved.normalized.json
@@ -4,22 +4,22 @@
     "messages": [
       {
         "column": 1,
-        "index": 0,
-        "line": 1,
+        "index": 25,
+        "line": 3,
         "loc": {
           "end": {
             "column": 2,
-            "line": 1
+            "line": 3
           },
           "start": {
             "column": 1,
-            "line": 1
+            "line": 3
           }
         },
         "message": "Coleman-Liau is 12.61. Keep it at 12 or lower.",
         "range": [
-          0,
-          1
+          25,
+          26
         ],
         "ruleId": "coleman-liau",
         "severity": 2,
@@ -27,22 +27,22 @@
       },
       {
         "column": 1,
-        "index": 0,
-        "line": 1,
+        "index": 25,
+        "line": 3,
         "loc": {
           "end": {
             "column": 2,
-            "line": 1
+            "line": 3
           },
           "start": {
             "column": 1,
-            "line": 1
+            "line": 3
           }
         },
         "message": "Flesch Reading Ease is 37.2. Keep it at 61 or higher.",
         "range": [
-          0,
-          1
+          25,
+          26
         ],
         "ruleId": "flesch-kincaid",
         "severity": 2,
@@ -50,22 +50,22 @@
       },
       {
         "column": 1,
-        "index": 0,
-        "line": 1,
+        "index": 25,
+        "line": 3,
         "loc": {
           "end": {
             "column": 2,
-            "line": 1
+            "line": 3
           },
           "start": {
             "column": 1,
-            "line": 1
+            "line": 3
           }
         },
         "message": "Gunning Fog is 19.08. Keep it at 12 or lower.",
         "range": [
-          0,
-          1
+          25,
+          26
         ],
         "ruleId": "gunning-fog",
         "severity": 2,

--- a/behavior/golden/textlint-rules-corpus-metrics-and-markdown/approved.meta.json
+++ b/behavior/golden/textlint-rules-corpus-metrics-and-markdown/approved.meta.json
@@ -1,10 +1,10 @@
 {
   "suite": "textlint-rules-corpus-metrics-and-markdown",
   "kind": "approved",
-  "run_id": "2026-07-24T10-32-33.25209Z-04547efb",
-  "run_commit": "ddf8160",
+  "run_id": "2026-07-24T19-13-37.870906Z-04547efb",
+  "run_commit": "51aa56d",
   "working_tree": "dirty",
-  "recorded_at": "2026-07-24T10:32:33.25209Z",
+  "recorded_at": "2026-07-24T19:13:37.870906Z",
   "fixture_hash": "sha256:f74d9cbdd8abd5a443916d0f0921a7950bc0261b393b9cc5e7102ce4c83e0744",
   "manifest_hash": "sha256:04547efbb13157ee3d8ef18dda767231fd63d3f9cc27c15317cf28c5f0583e7b",
   "tool_version": "0.1.8",
@@ -15,5 +15,5 @@
       "sha256": "sha256:4dfb3aadf405eefb187c3bcf18f674a412ed1153123e655e97e97a8b987c3451"
     }
   ],
-  "comment": "Normalize fixture paths relative to repository; findings unchanged"
+  "comment": "Reviewed vague-change templates, quietly density, and corrected document source offsets."
 }

--- a/behavior/golden/textlint-rules-corpus-metrics-and-markdown/approved.normalized.json
+++ b/behavior/golden/textlint-rules-corpus-metrics-and-markdown/approved.normalized.json
@@ -4,22 +4,22 @@
     "messages": [
       {
         "column": 1,
-        "index": 0,
-        "line": 1,
+        "index": 33,
+        "line": 3,
         "loc": {
           "end": {
             "column": 2,
-            "line": 1
+            "line": 3
           },
           "start": {
             "column": 1,
-            "line": 1
+            "line": 3
           }
         },
         "message": "Coleman-Liau is 19.09. Keep it at 12 or lower.",
         "range": [
-          0,
-          1
+          33,
+          34
         ],
         "ruleId": "coleman-liau",
         "severity": 2,
@@ -27,22 +27,22 @@
       },
       {
         "column": 1,
-        "index": 0,
-        "line": 1,
+        "index": 33,
+        "line": 3,
         "loc": {
           "end": {
             "column": 2,
-            "line": 1
+            "line": 3
           },
           "start": {
             "column": 1,
-            "line": 1
+            "line": 3
           }
         },
         "message": "Flesch Reading Ease is 27.86. Keep it at 61 or higher.",
         "range": [
-          0,
-          1
+          33,
+          34
         ],
         "ruleId": "flesch-kincaid",
         "severity": 2,
@@ -50,22 +50,22 @@
       },
       {
         "column": 1,
-        "index": 0,
-        "line": 1,
+        "index": 33,
+        "line": 3,
         "loc": {
           "end": {
             "column": 2,
-            "line": 1
+            "line": 3
           },
           "start": {
             "column": 1,
-            "line": 1
+            "line": 3
           }
         },
         "message": "Gunning Fog is 14.6. Keep it at 12 or lower.",
         "range": [
-          0,
-          1
+          33,
+          34
         ],
         "ruleId": "gunning-fog",
         "severity": 2,

--- a/behavior/golden/textlint-rules-corpus-narrative-scenes/approved.meta.json
+++ b/behavior/golden/textlint-rules-corpus-narrative-scenes/approved.meta.json
@@ -1,10 +1,10 @@
 {
   "suite": "textlint-rules-corpus-narrative-scenes",
   "kind": "approved",
-  "run_id": "2026-07-24T10-32-38.83752Z-04547efb",
-  "run_commit": "ddf8160",
+  "run_id": "2026-07-24T19-13-42.430496Z-04547efb",
+  "run_commit": "51aa56d",
   "working_tree": "dirty",
-  "recorded_at": "2026-07-24T10:32:38.83752Z",
+  "recorded_at": "2026-07-24T19:13:42.430496Z",
   "fixture_hash": "sha256:5b02c536cc4037058cfcb50ca69fa3700d32985e81455f218eb3bec3a978537d",
   "manifest_hash": "sha256:04547efbb13157ee3d8ef18dda767231fd63d3f9cc27c15317cf28c5f0583e7b",
   "tool_version": "0.1.8",
@@ -15,5 +15,5 @@
       "sha256": "sha256:86a8690dcdf6d1d90fcd58fb99d00af1ae06618dfd427dc5a4cea25de966caeb"
     }
   ],
-  "comment": "Normalize fixture paths relative to repository; findings unchanged"
+  "comment": "Reviewed vague-change templates, quietly density, and corrected document source offsets."
 }

--- a/behavior/golden/textlint-rules-corpus-narrative-scenes/approved.normalized.json
+++ b/behavior/golden/textlint-rules-corpus-narrative-scenes/approved.normalized.json
@@ -4,22 +4,22 @@
     "messages": [
       {
         "column": 1,
-        "index": 0,
-        "line": 1,
+        "index": 25,
+        "line": 3,
         "loc": {
           "end": {
             "column": 2,
-            "line": 1
+            "line": 3
           },
           "start": {
             "column": 1,
-            "line": 1
+            "line": 3
           }
         },
         "message": "Gunning Fog is 12.11. Keep it at 12 or lower.",
         "range": [
-          0,
-          1
+          25,
+          26
         ],
         "ruleId": "gunning-fog",
         "severity": 2,

--- a/behavior/golden/textlint-rules-corpus-technical-terminology/approved.meta.json
+++ b/behavior/golden/textlint-rules-corpus-technical-terminology/approved.meta.json
@@ -1,10 +1,10 @@
 {
   "suite": "textlint-rules-corpus-technical-terminology",
   "kind": "approved",
-  "run_id": "2026-07-24T10-32-41.994548Z-04547efb",
-  "run_commit": "ddf8160",
+  "run_id": "2026-07-24T19-13-44.679183Z-04547efb",
+  "run_commit": "51aa56d",
   "working_tree": "dirty",
-  "recorded_at": "2026-07-24T10:32:41.994548Z",
+  "recorded_at": "2026-07-24T19:13:44.679183Z",
   "fixture_hash": "sha256:cf2a47f40dea485af298ac2a33969a33ad231b2ce88ba03fdc63b4ad27723ff0",
   "manifest_hash": "sha256:04547efbb13157ee3d8ef18dda767231fd63d3f9cc27c15317cf28c5f0583e7b",
   "tool_version": "0.1.8",
@@ -15,5 +15,5 @@
       "sha256": "sha256:e56e6ed5b1d94558aecd64c1844affcea9a6e6b7189ece747581949b27d3a870"
     }
   ],
-  "comment": "Normalize fixture paths relative to repository; findings unchanged"
+  "comment": "Reviewed vague-change templates, quietly density, and corrected document source offsets."
 }

--- a/behavior/golden/textlint-rules-corpus-technical-terminology/approved.normalized.json
+++ b/behavior/golden/textlint-rules-corpus-technical-terminology/approved.normalized.json
@@ -4,22 +4,22 @@
     "messages": [
       {
         "column": 1,
-        "index": 0,
-        "line": 1,
+        "index": 31,
+        "line": 3,
         "loc": {
           "end": {
             "column": 2,
-            "line": 1
+            "line": 3
           },
           "start": {
             "column": 1,
-            "line": 1
+            "line": 3
           }
         },
         "message": "Flesch Reading Ease is 53.1. Keep it at 61 or higher.",
         "range": [
-          0,
-          1
+          31,
+          32
         ],
         "ruleId": "flesch-kincaid",
         "severity": 2,
@@ -27,22 +27,22 @@
       },
       {
         "column": 1,
-        "index": 0,
-        "line": 1,
+        "index": 31,
+        "line": 3,
         "loc": {
           "end": {
             "column": 2,
-            "line": 1
+            "line": 3
           },
           "start": {
             "column": 1,
-            "line": 1
+            "line": 3
           }
         },
         "message": "Recommended terms present: 3. Include at least 4 terms from the policy pool.",
         "range": [
-          0,
-          1
+          31,
+          32
         ],
         "ruleId": "recommended-terms",
         "severity": 2,
@@ -50,22 +50,22 @@
       },
       {
         "column": 1,
-        "index": 0,
-        "line": 1,
+        "index": 31,
+        "line": 3,
         "loc": {
           "end": {
             "column": 2,
-            "line": 1
+            "line": 3
           },
           "start": {
             "column": 1,
-            "line": 1
+            "line": 3
           }
         },
         "message": "Required term missing: \"borrowing\". Add the term or update the policy.",
         "range": [
-          0,
-          1
+          31,
+          32
         ],
         "ruleId": "required-terms",
         "severity": 2,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "slopless",
-  "version": "0.2.27",
+  "version": "0.2.28",
   "description": "Deterministic textlint rules and CLI for catching prose slop in English Markdown.",
   "keywords": [
     "textlint",
@@ -122,7 +122,8 @@
     "./rules/words/llm-vocabulary-density": "./dist/rules/words/llm-vocabulary-density.js",
     "./rules/words/llm-vocabulary": "./dist/rules/words/llm-vocabulary.js",
     "./rules/words/simplicity": "./dist/rules/words/simplicity.js",
-    "./rules/words/prohibited-words": "./dist/rules/words/prohibited-words.js"
+    "./rules/words/prohibited-words": "./dist/rules/words/prohibited-words.js",
+    "./rules/words/quietly-overuse": "./dist/rules/words/quietly-overuse.js"
   },
   "dependencies": {
     "@textlint/ast-node-types": "15.7.1",

--- a/src/adapters/textlint/units.ts
+++ b/src/adapters/textlint/units.ts
@@ -15,7 +15,10 @@ import {
   sectionFirstSentences,
   sectionLastSentences
 } from "../../shared/text/sections.js";
-import { documentText } from "../../shared/text/document.js";
+import {
+  documentSourceText,
+  documentText
+} from "../../shared/text/document.js";
 import type { SourceRange, TextUnit } from "../../rules/types.js";
 import { sourceText } from "../../shared/text/traverse.js";
 
@@ -86,7 +89,8 @@ function sentenceUnit(
 }
 
 export function documentUnit(document: TxtDocumentNode): TextUnit {
-  const text = documentText(document);
+  const source = documentSourceText(document);
+  const { text } = source;
 
   return {
     id: "document:0",
@@ -94,7 +98,10 @@ export function documentUnit(document: TxtDocumentNode): TextUnit {
     node: document,
     normalizedText: normalizeForMatch(text),
     range: { end: text.length, start: 0 },
-    sourceRangeFor: (range) => range,
+    sourceRangeFor: (range) => ({
+      end: source.originalEndFor(range.end),
+      start: source.originalStartFor(range.start)
+    }),
     text
   };
 }

--- a/src/presets/everything.ts
+++ b/src/presets/everything.ts
@@ -42,6 +42,7 @@ export const everything = {
     "perception-verb-density": true,
     "prohibited-phrases": true,
     "prohibited-words": true,
+    "quietly-overuse": true,
     "recommended-terms": true,
     redundancy: true,
     "repeated-predicate-end": true,

--- a/src/registries/words.ts
+++ b/src/registries/words.ts
@@ -3,6 +3,7 @@ import hedgeStacking from "../rules/words/hedge-stacking.js";
 import llmVocabularyDensity from "../rules/words/llm-vocabulary-density.js";
 import llmVocabulary from "../rules/words/llm-vocabulary.js";
 import prohibitedWords from "../rules/words/prohibited-words.js";
+import quietlyOveruse from "../rules/words/quietly-overuse.js";
 import simplicity from "../rules/words/simplicity.js";
 
 export const wordRules = {
@@ -11,5 +12,6 @@ export const wordRules = {
   "llm-vocabulary-density": llmVocabularyDensity,
   "llm-vocabulary": llmVocabulary,
   "prohibited-words": prohibitedWords,
+  "quietly-overuse": quietlyOveruse,
   simplicity
 };

--- a/src/rules/semantic-thinness/patterns/something-shifted.json
+++ b/src/rules/semantic-thinness/patterns/something-shifted.json
@@ -2,14 +2,36 @@
   "id": "something-shifted",
   "class": "vague-change",
   "purpose": "Catch vague change declarations that say something shifted, changed, moved, or crossed a line without naming the concrete change.",
-  "matchMode": "contains",
+  "matchMode": "full",
   "maxTokens": 80,
   "templates": [
-    "{genericSubject} {changeVerb}.",
-    "{genericSubject} had {changeVerb}.",
-    "{genericSubject} in {abstractContainer} had {changeVerb}.",
-    "{concreteSubject} did not {changeVerb}, but {genericSubject} in it did.",
-    "{genericSubject} {changeVerb} when {genericSubject} {abstractAction}."
+    {
+      "text": "{genericSubject} {changeVerb}.",
+      "matchMode": "contains"
+    },
+    {
+      "text": "{genericSubject} had {changeVerb}.",
+      "matchMode": "contains"
+    },
+    {
+      "text": "{genericSubject} in {abstractContainer} had {changeVerb}.",
+      "matchMode": "contains"
+    },
+    {
+      "text": "{concreteSubject} did not {changeVerb}, but {genericSubject} in it did.",
+      "matchMode": "contains"
+    },
+    {
+      "text": "{genericSubject} {changeVerb} when {genericSubject} {abstractAction}.",
+      "matchMode": "contains"
+    },
+    "{diffuseSubject} {weakMannerAdverb} {finiteChange}.",
+    "{diffuseSubject} {progressiveAuxiliary} {weakMannerAdverb} {progressiveChange}.",
+    "{diffuseSubject} {perfectAuxiliary} {weakMannerAdverb} {pastChange}.",
+    "{diffuseSubject} {finiteChange} {weakMannerAdverb}.",
+    "{deicticSubject} {weakMannerAdverb} {emptyChangeObject}.",
+    "{shiftDeterminer} {shiftModifier} shift {emptyShiftPredicate}.",
+    "{deicticSubject} {signalVerb} {shiftDeterminer} {shiftModifier} shift."
   ],
   "slots": {
     "genericSubject": [
@@ -45,7 +67,103 @@
       "chose differently",
       "named the truth",
       "let go"
-    ]
+    ],
+    "diffuseSubject": [
+      "the market",
+      "the industry",
+      "search",
+      "the web",
+      "the landscape",
+      "the platform",
+      "the system",
+      "the process",
+      "the conversation",
+      "the work",
+      "the strategy",
+      "the model",
+      "the product",
+      "the category",
+      "the space"
+    ],
+    "progressiveAuxiliary": ["is", "was", "has been", "had been"],
+    "perfectAuxiliary": ["has", "had"],
+    "weakMannerAdverb": [
+      "quietly",
+      "silently",
+      "subtly",
+      "gradually",
+      "steadily",
+      "almost invisibly",
+      "under the surface"
+    ],
+    "finiteChange": [
+      "changes",
+      "shifts",
+      "evolves",
+      "transforms",
+      "reshapes",
+      "redefines",
+      "moves",
+      "changed",
+      "shifted",
+      "evolved",
+      "transformed",
+      "reshaped",
+      "redefined",
+      "moved"
+    ],
+    "pastChange": [
+      "changed",
+      "shifted",
+      "evolved",
+      "transformed",
+      "reshaped",
+      "redefined",
+      "moved"
+    ],
+    "progressiveChange": [
+      "changing",
+      "shifting",
+      "evolving",
+      "transforming",
+      "reshaping",
+      "redefining",
+      "moving"
+    ],
+    "deicticSubject": ["this", "that", "it"],
+    "emptyChangeObject": [
+      "changes everything",
+      "changes the game",
+      "changes the equation",
+      "reshapes everything",
+      "redefines everything"
+    ],
+    "shiftDeterminer": ["a", "the", "this", "that"],
+    "shiftModifier": [
+      "quiet",
+      "subtle",
+      "broader",
+      "meaningful",
+      "important",
+      "major",
+      "fundamental",
+      "seismic",
+      "structural",
+      "profound",
+      "significant",
+      "notable"
+    ],
+    "emptyShiftPredicate": [
+      "is underway",
+      "is happening",
+      "has begun",
+      "is already here",
+      "is easy to miss",
+      "is hard to ignore",
+      "matters",
+      "changes everything"
+    ],
+    "signalVerb": ["marks", "signals", "represents", "reflects"]
   },
   "rejectIf": [
     "sentence names what changed",

--- a/src/rules/words/actually-overuse.ts
+++ b/src/rules/words/actually-overuse.ts
@@ -1,8 +1,6 @@
-import { defineTextlintRule } from "../../adapters/textlint/rule.js";
-import { documentUnit } from "../../adapters/textlint/units.js";
 import { ERROR_SEVERITY } from "../../reporting/density.js";
 import type { RuleId } from "../types.js";
-import { wordTokens } from "../../shared/text/tokens.js";
+import { defineExactTokenDensityRule } from "./private/token-density-rule.js";
 
 // The rule only detects occurrences of "actually" - one detection per use, no counting,
 // rate, or severity. The density-rate report policy below lets the reporter judge the
@@ -12,23 +10,8 @@ import { wordTokens } from "../../shared/text/tokens.js";
 const TARGET = "actually";
 const RULE_ID = "words:actually-overuse" satisfies RuleId;
 
-const rule = defineTextlintRule({
-  detector: {
-    detect: ({ units }) =>
-      units.flatMap((unit) =>
-        wordTokens(unit.text)
-          .filter((token) => token.normalized === TARGET)
-          .map((token) => ({
-            evidence: TARGET,
-            label: TARGET,
-            range: { end: token.end, start: token.start },
-            ruleId: RULE_ID,
-            unitId: unit.id
-          }))
-      ),
-    family: "words",
-    id: RULE_ID
-  },
+const rule = defineExactTokenDensityRule({
+  errorPerUnit: 2,
   formatMessage: (report) => {
     const count = report.metric?.["count"] ?? report.detections.length;
     const perUnit = report.metric?.["perUnit"] ?? 0;
@@ -39,15 +22,11 @@ const rule = defineTextlintRule({
 
     return `"actually" used ${count} times (${perUnit} per 1,000 words), ${threshold}. Cut the filler uses; keep at most about one per 1,000 words.`;
   },
-  reportPolicy: {
-    errorPerUnit: 2,
-    kind: "density-rate",
-    minimumOccurrences: 2,
-    scope: "document",
-    warningPerUnit: 1,
-    wordsPerUnit: 1000
-  },
-  units: (document) => [documentUnit(document)]
+  minimumOccurrences: 2,
+  ruleId: RULE_ID,
+  target: TARGET,
+  warningPerUnit: 1,
+  wordsPerUnit: 1000
 });
 
 export default rule;

--- a/src/rules/words/private/token-density-rule.ts
+++ b/src/rules/words/private/token-density-rule.ts
@@ -1,0 +1,49 @@
+import type { TextlintRuleModule } from "@textlint/types";
+import { defineTextlintRule } from "../../../adapters/textlint/rule.js";
+import { documentUnit } from "../../../adapters/textlint/units.js";
+import type { RuleReport } from "../../../reporting/types.js";
+import { wordTokens } from "../../../shared/text/tokens.js";
+import type { RuleId } from "../../types.js";
+
+type ExactTokenDensityRuleConfig = {
+  readonly errorPerUnit: number;
+  readonly formatMessage: (report: RuleReport) => string;
+  readonly minimumOccurrences: number;
+  readonly ruleId: RuleId;
+  readonly target: string;
+  readonly warningPerUnit: number;
+  readonly wordsPerUnit: number;
+};
+
+export function defineExactTokenDensityRule(
+  config: ExactTokenDensityRuleConfig
+): TextlintRuleModule<Record<string, never>> {
+  return defineTextlintRule({
+    detector: {
+      detect: ({ units }) =>
+        units.flatMap((unit) =>
+          wordTokens(unit.text)
+            .filter((token) => token.normalized === config.target)
+            .map((token) => ({
+              evidence: config.target,
+              label: config.target,
+              range: { end: token.end, start: token.start },
+              ruleId: config.ruleId,
+              unitId: unit.id
+            }))
+        ),
+      family: "words",
+      id: config.ruleId
+    },
+    formatMessage: config.formatMessage,
+    reportPolicy: {
+      errorPerUnit: config.errorPerUnit,
+      kind: "density-rate",
+      minimumOccurrences: config.minimumOccurrences,
+      scope: "document",
+      warningPerUnit: config.warningPerUnit,
+      wordsPerUnit: config.wordsPerUnit
+    },
+    units: (document) => [documentUnit(document)]
+  });
+}

--- a/src/rules/words/quietly-overuse.ts
+++ b/src/rules/words/quietly-overuse.ts
@@ -1,0 +1,27 @@
+import { ERROR_SEVERITY } from "../../reporting/density.js";
+import type { RuleId } from "../types.js";
+import { defineExactTokenDensityRule } from "./private/token-density-rule.js";
+
+const TARGET = "quietly";
+const RULE_ID = "words:quietly-overuse" satisfies RuleId;
+
+const rule = defineExactTokenDensityRule({
+  errorPerUnit: 2,
+  formatMessage: (report) => {
+    const count = report.metric?.["count"] ?? report.detections.length;
+    const perUnit = report.metric?.["perUnit"] ?? 0;
+    const threshold =
+      report.severity === ERROR_SEVERITY
+        ? "above the 2-per-1,000-word error threshold"
+        : "above the 1-per-1,000-word warning threshold";
+
+    return `"quietly" used ${count} times (${perUnit} per 1,000 words), ${threshold}. Cut the filler uses; keep at most about one per 1,000 words.`;
+  },
+  minimumOccurrences: 4,
+  ruleId: RULE_ID,
+  target: TARGET,
+  warningPerUnit: 1,
+  wordsPerUnit: 1000
+});
+
+export default rule;

--- a/src/shared/text/document.ts
+++ b/src/shared/text/document.ts
@@ -1,9 +1,62 @@
 import type { TxtDocumentNode } from "@textlint/ast-node-types";
 import { allParagraphs } from "./sections.js";
+import type { SourceText } from "./traverse.js";
+
+type DocumentParagraph = {
+  readonly outputEnd: number;
+  readonly outputStart: number;
+  readonly paragraph: ReturnType<typeof allParagraphs>[number];
+  readonly trimStart: number;
+};
+
+function trimStartLength(text: string): number {
+  return text.length - text.trimStart().length;
+}
+
+export function documentSourceText(document: TxtDocumentNode): SourceText {
+  const paragraphs: DocumentParagraph[] = [];
+  const textParts: string[] = [];
+  let outputStart = 0;
+
+  for (const paragraph of allParagraphs(document)) {
+    const text = paragraph.text.trim();
+    if (text.length === 0) {
+      continue;
+    }
+
+    paragraphs.push({
+      outputEnd: outputStart + text.length,
+      outputStart,
+      paragraph,
+      trimStart: trimStartLength(paragraph.text)
+    });
+    textParts.push(text);
+    outputStart += text.length + 2;
+  }
+
+  const originalOffsetFor = (offset: number, isEnd: boolean): number => {
+    const mapped = paragraphs.find(
+      (paragraph) =>
+        offset >= paragraph.outputStart && offset <= paragraph.outputEnd
+    );
+    if (mapped === undefined) {
+      return offset;
+    }
+
+    const paragraphOffset = mapped.trimStart + offset - mapped.outputStart;
+    const localOffset = isEnd
+      ? mapped.paragraph.source.originalEndFor(paragraphOffset)
+      : mapped.paragraph.source.originalStartFor(paragraphOffset);
+    return mapped.paragraph.paragraph.range[0] + localOffset;
+  };
+
+  return {
+    originalEndFor: (end) => originalOffsetFor(end, true),
+    originalStartFor: (start) => originalOffsetFor(start, false),
+    text: textParts.join("\n\n")
+  };
+}
 
 export function documentText(document: TxtDocumentNode): string {
-  return allParagraphs(document)
-    .map((paragraph) => paragraph.text.trim())
-    .filter((text) => text.length > 0)
-    .join("\n\n");
+  return documentSourceText(document).text;
 }

--- a/src/shared/text/sections.ts
+++ b/src/shared/text/sections.ts
@@ -5,7 +5,7 @@ import type {
   TxtParentNode
 } from "@textlint/ast-node-types";
 import { type SplitSentence, splitSentences } from "./sentences.js";
-import { type SourceText, sourceText } from "./traverse.js";
+import { proseSourceText, type SourceText, sourceText } from "./traverse.js";
 
 type Section = readonly AnyTxtNode[];
 
@@ -27,30 +27,6 @@ function isParagraphNode(node: AnyTxtNode): node is TxtParagraphNode {
 
 function isParentNode(node: AnyTxtNode): node is TxtParentNode {
   return "children" in node;
-}
-
-type NodeWithValue = AnyTxtNode & {
-  readonly value: string;
-};
-
-function hasStringValue(node: AnyTxtNode): node is NodeWithValue {
-  return "value" in node && typeof node.value === "string";
-}
-
-function plainText(node: AnyTxtNode): string {
-  if (hasStringValue(node)) {
-    return node.value;
-  }
-
-  if (node.type === "Break") {
-    return " ";
-  }
-
-  if (!isParentNode(node)) {
-    return "";
-  }
-
-  return node.children.map((child) => plainText(child)).join("");
 }
 
 function collectParagraphs(
@@ -133,10 +109,11 @@ export function allParagraphs(document: TxtDocumentNode): SectionParagraph[] {
 
   for (const section of documentSections(document)) {
     for (const paragraph of sectionParagraphs(section)) {
+      const source = proseSourceText(paragraph);
       paragraphs.push({
         paragraph,
-        source: sourceText(paragraph),
-        text: plainText(paragraph)
+        source,
+        text: source.text
       });
     }
   }

--- a/src/shared/text/traverse.ts
+++ b/src/shared/text/traverse.ts
@@ -1,4 +1,8 @@
-import type { TxtParentNode } from "@textlint/ast-node-types";
+import type {
+  AnyTxtNode,
+  TxtParentNode,
+  TxtStrNode
+} from "@textlint/ast-node-types";
 import { StringSource } from "textlint-util-to-string";
 
 export type SourceText = {
@@ -7,11 +11,70 @@ export type SourceText = {
   readonly text: string;
 };
 
-export function sourceText(node: TxtParentNode): SourceText {
+function isParentNode(node: AnyTxtNode): node is TxtParentNode {
+  return "children" in node;
+}
+
+function isHtmlNode(
+  node: AnyTxtNode
+): node is AnyTxtNode & { readonly value: string } {
+  return (
+    node.type === "Html" && "value" in node && typeof node.value === "string"
+  );
+}
+
+function normalizeNode(node: AnyTxtNode, includeImageAlt: boolean): AnyTxtNode {
+  if (node.type === "Break") {
+    return {
+      ...node,
+      type: "Str",
+      value: " "
+    } satisfies TxtStrNode;
+  }
+
+  if (
+    (node.type === "Image" || node.type === "ImageReference") &&
+    !includeImageAlt
+  ) {
+    return {
+      ...node,
+      type: "Str",
+      value: ""
+    } satisfies TxtStrNode;
+  }
+
+  if (isHtmlNode(node) && !includeImageAlt) {
+    return {
+      ...node,
+      type: "Str",
+      value: node.value
+    } satisfies TxtStrNode;
+  }
+
+  if (!isParentNode(node)) {
+    return node;
+  }
+
+  return {
+    ...node,
+    // type-coverage:ignore-next-line
+    children: node.children.map((child) =>
+      normalizeNode(child, includeImageAlt)
+    ) as typeof node.children
+  };
+}
+
+function mappedSourceText(
+  node: TxtParentNode,
+  includeImageAlt: boolean
+): SourceText {
   // textlint-util-to-string has not updated its public type for textlint 15.7's
   // readonly children, but it only reads the node at runtime.
   const source = new StringSource(
-    node as ConstructorParameters<typeof StringSource>[0] // type-coverage:ignore-line
+    // type-coverage:ignore-next-line
+    normalizeNode(node, includeImageAlt) as ConstructorParameters<
+      typeof StringSource
+    >[0]
   );
 
   return {
@@ -19,4 +82,12 @@ export function sourceText(node: TxtParentNode): SourceText {
     originalStartFor: (start) => source.originalIndexFromIndex(start) ?? start,
     text: source.toString()
   };
+}
+
+export function proseSourceText(node: TxtParentNode): SourceText {
+  return mappedSourceText(node, false);
+}
+
+export function sourceText(node: TxtParentNode): SourceText {
+  return mappedSourceText(node, true);
 }


### PR DESCRIPTION
## Summary

- broaden the existing vague-change semantic templates for weak manner adverbs and empty shift framing
- add per-document `quietly` density reporting with warning and error rates
- map document-level findings back to Markdown source offsets without changing density input
- add reviewed hit, no-hit, warning, boundary, hard-break, and corpus coverage

## Verification

- `pnpm run validate`
- `fixture3 doctor --json`
- `fixture3 check --all --json` (19 suites matched)
- `specular lint` and `specular verify` (`conforms: true`)
- preserve parity: 1,730 records, 0 missing, 0 invalid
- targeted audit: 13,705 human files, 402 generated-AI files, 1,501 suspected-AI files
- adversarial review: no remaining blocker
