### PR TITLE
Catch vague shift impact claims

### DIFF
--- a/.plans/2026-07-28-122116-vague-shift-impact-claims.md
+++ b/.plans/2026-07-28-122116-vague-shift-impact-claims.md
@@ -1,0 +1,119 @@
+# Goal
+
+Catch both reported sentences through existing public rules:
+
+- `That shift changed everything.` through
+  `semantic-thinness:semantic-thinness`.
+- `Some of the biggest shifts in leadership come from experiences outside
+  work.` through `syntactic-patterns:universalizing-claims`.
+
+The implementation must generalize beyond those literals while preserving
+concrete descriptions of measured, physical, historical, or named changes.
+
+# Existing Architecture
+
+- `hollow-significance.json` already catches deictic total-impact claims such
+  as `It changed everything`, but its subject slots do not accept summary
+  change nouns such as `that shift`.
+- `universalizing-claims.ts` already owns unsupported broad claims. It matches
+  broad human groups plus desire or certainty verbs, but it does not match
+  superlative abstract outcomes attributed to vague sources.
+- Both rules report one finding for one sentence. Density is not involved.
+- Fixture3 case files contain isolated hits and no-hits. The engineering-review
+  corpus preserves the same cases in readable prose.
+
+# Hollow Significance Expansion
+
+1. Extend the existing `hollow-significance` pattern instead of adding a rule
+   or pattern ID.
+2. Add a full-sentence template combining a summary subject with a total-impact
+   phrase.
+3. Cover deictic and definite summary subjects such as `this shift`, `that
+   shift`, `the shift`, `this change`, `that change`, `the decision`, `that
+   move`, and `the experience`.
+4. Cover total-impact phrases such as `changed everything`, `changes
+   everything`, `transformed everything`, `reshaped everything`, `changed the
+   whole picture`, and `made all the difference`.
+5. Continue using the existing broad-pattern concrete-evidence rejection.
+   Sentences with measurements, dates, named mechanisms, or explanatory
+   clauses must remain no-hits.
+
+# Universalizing Claims Expansion
+
+1. Extend `syntactic-patterns:universalizing-claims`; do not add another rule.
+2. Match the grammatical sequence:
+   `some/many of the + superlative + abstract plural outcome + optional
+   abstract domain + vague source predicate`.
+3. Superlatives include `biggest`, `greatest`, `deepest`, `strongest`,
+   `best`, `most important`, `most valuable`, `most useful`, and `most
+   meaningful`.
+4. Abstract outcomes include `shifts`, `changes`, `lessons`, `ideas`,
+   `insights`, `breakthroughs`, `improvements`, `advances`, `decisions`, and
+   `skills`.
+5. Abstract domains include `leadership`, `business`, `careers`, `life`,
+   `management`, `strategy`, `growth`, `work`, `writing`, `design`, and
+   `technology`.
+6. Source predicates include `come/came from`, `grow/grew from`,
+   `emerge/emerged from`, `start/started with`, and `begin/began with`.
+7. Vague sources include `experience`, `experiences`, `experiences outside
+   work`, `failure`, `failures`, `adversity`, `discomfort`, `setbacks`,
+   `challenges`, `unexpected places`, `ordinary moments`, and `elsewhere`.
+8. Require the complete sentence shape. Do not match physical or measured
+   shifts, named source events, customer research, chapter references,
+   numbered evidence, or a different predicate.
+
+# Fixtures And Corpus
+
+1. Add at least 12 hollow-significance hit variants and 12 concrete no-hit
+   controls.
+2. Add at least 18 superlative-source hit variants across qualifiers, outcomes,
+   domains, predicates, and sources.
+3. Add at least 18 no-hit controls covering geological movement, surveys,
+   named events, numbered results, specific research sources, manuals,
+   concrete mechanisms, and near-miss grammar.
+4. Put every new case sentence into the engineering-review corpus as readable
+   topic-grouped prose.
+5. Add preserve records that map every new corpus sentence to its exact case
+   file line.
+6. Run Fixture3 before implementation and confirm the two reported sentences
+   do not have the intended rule findings.
+7. After implementation, review every changed finding before approval. Do not
+   remove no-hit cases to make output pass.
+
+# Verification And Release
+
+1. Bump the package patch version from `0.2.31` to `0.2.32`.
+2. Run `specular lint` and `specular verify`.
+3. Run `fixture3 doctor`, inspect the affected suites, review their diffs, and
+   run `fixture3 check --all`.
+4. Run `pnpm run validate`.
+5. Run the packaged and globally installed CLI against both reported
+   sentences and representative no-hits.
+6. Perform one adversarial review of the plan, specification, implementation,
+   fixture changes, and verification output.
+7. Commit and push with Eugene Tartakovsky's configured authorship, merge only
+   after CI passes, publish `v0.2.32`, and install it globally.
+
+# Key Decisions
+
+- Reuse `hollow-significance` because the first sentence is an unsupported
+  total-impact summary, not a new kind of change detector.
+- Reuse `universalizing-claims` because the second sentence generalizes from a
+  vague source using an inflated superlative frame.
+- Keep the patterns separate because their grammar and false-positive
+  boundaries differ.
+- Use explicit linguistic slots. Matching any noun, adjective, or source would
+  flag ordinary factual claims.
+
+# Files To Modify
+
+- `src/rules/semantic-thinness/patterns/hollow-significance.json`
+- `src/rules/syntactic-patterns/generalization/universalizing-claims.ts`
+- `behavior/fixtures/textlint-rules/cases/semantic-thinness/hits.md`
+- `behavior/fixtures/textlint-rules/cases/semantic-thinness/no-hits.md`
+- `behavior/fixtures/textlint-rules/cases/syntactic-patterns/hits.md`
+- `behavior/fixtures/textlint-rules/cases/syntactic-patterns/no-hits.md`
+- `behavior/fixtures/textlint-rules/corpus/engineering-review.md`
+- `behavior/fixtures/textlint-rules/corpus/engineering-review.preserve.json`
+- `behavior/golden/*` only through reviewed Fixture3 approval
+- `package.json`

--- a/.plans/2026-07-28-122116-vague-shift-impact-claims.md.coverage.md
+++ b/.plans/2026-07-28-122116-vague-shift-impact-claims.md.coverage.md
@@ -1,0 +1,9 @@
+# Coverage Map
+
+- Hollow significance expansion: `src/rules/semantic-thinness/patterns/hollow-significance.json`
+- Universalizing claim expansion: `src/rules/syntactic-patterns/generalization/universalizing-claims.ts`
+- Isolated semantic hits and no-hits: `behavior/fixtures/textlint-rules/cases/semantic-thinness/`
+- Isolated syntactic hits and no-hits: `behavior/fixtures/textlint-rules/cases/syntactic-patterns/`
+- Flowing prose and exact-case preservation: `behavior/fixtures/textlint-rules/corpus/engineering-review.md` and its preserve file
+- Public output approvals: the existing Fixture3 suites for those case and corpus files
+- Release version: `package.json`

--- a/.plans/2026-07-28-122116-vague-shift-impact-claims.md.spec.json
+++ b/.plans/2026-07-28-122116-vague-shift-impact-claims.md.spec.json
@@ -1,0 +1,45 @@
+{
+  "version": 4,
+  "requirements": {
+    "tree": {
+      "verifier": ["builtin:tree"],
+      "reason": "The plan extends two existing rules and their public fixtures without adding a new rule.",
+      "required": [
+        "src/rules/semantic-thinness/patterns/hollow-significance.json",
+        "src/rules/syntactic-patterns/generalization/universalizing-claims.ts",
+        "behavior/fixtures/textlint-rules/cases/semantic-thinness/hits.md",
+        "behavior/fixtures/textlint-rules/cases/semantic-thinness/no-hits.md",
+        "behavior/fixtures/textlint-rules/cases/syntactic-patterns/hits.md",
+        "behavior/fixtures/textlint-rules/cases/syntactic-patterns/no-hits.md",
+        "behavior/fixtures/textlint-rules/corpus/engineering-review.md",
+        "behavior/fixtures/textlint-rules/corpus/engineering-review.preserve.json",
+        "package.json"
+      ],
+      "forbidden": [
+        "src/rules/**/vague-shift-impact-claims.ts",
+        "src/rules/**/vague-shift-impact-claims.json"
+      ]
+    },
+    "content": [
+      {
+        "verifier": ["builtin:content"],
+        "files": ["src/rules/semantic-thinness/patterns/hollow-significance.json"],
+        "reason": "Retain and extend the existing semantic pattern.",
+        "required": ["\"id\": \"hollow-significance\""]
+      },
+      {
+        "verifier": ["builtin:content"],
+        "files": ["src/rules/syntactic-patterns/generalization/universalizing-claims.ts"],
+        "reason": "Retain and extend the existing sentence rule.",
+        "required": ["ruleId: \"syntactic-patterns:universalizing-claims\"", "export default rule"]
+      },
+      {
+        "verifier": ["builtin:content"],
+        "files": ["package.json"],
+        "reason": "Publish the matcher expansion as version 0.2.32.",
+        "required": ["\"version\": \"0.2.32\""],
+        "forbidden": ["\"version\": \"0.2.31\""]
+      }
+    ]
+  }
+}

--- a/.worklogs/2026-07-28-123840-vague-shift-impact-claims.md
+++ b/.worklogs/2026-07-28-123840-vague-shift-impact-claims.md
@@ -1,0 +1,36 @@
+# Summary
+
+Expanded two existing rule owners to catch unsupported total-impact statements and vague superlative claims about the source of important changes. Added 30 hit cases, 30 no-hit controls, matching engineering-review corpus prose, exact preservation metadata, and reviewed Fixture3 approvals.
+
+# Decisions made
+
+- Extended `hollow-significance` instead of adding a rule. Full-sentence templates combine a bounded summary subject with a total-impact verb and object.
+- Extended `universalizing-claims` instead of adding a rule. The matcher requires the complete sequence: broad quantity, importance qualifier, abstract outcome, optional abstract domain, source predicate, and vague source.
+- Kept measured changes, named causes, physical changes, named studies, named people, and narrower sentence structures outside both matchers.
+- Recomputed every engineering-review preserve line after fixture insertion exposed stale line numbers.
+- Bumped the package from 0.2.31 to 0.2.32.
+
+# Key files for context
+
+- `.plans/2026-07-28-122116-vague-shift-impact-claims.md`
+- `.plans/2026-07-28-122116-vague-shift-impact-claims.md.spec.json`
+- `src/rules/semantic-thinness/patterns/hollow-significance.json`
+- `src/rules/syntactic-patterns/generalization/universalizing-claims.ts`
+- `behavior/fixtures/textlint-rules/corpus/engineering-review.preserve.json`
+
+# Verification
+
+- `specular lint` and `specular verify` pass.
+- `pnpm run validate` passes.
+- `fixture3 doctor` passes.
+- `fixture3 check --all` passes.
+- All 30 added hit cases fire under their intended rule in cases and corpus.
+- All 30 added no-hit controls receive no finding in isolated case files and no finding from either expanded rule in the corpus.
+- A packed local install reports both user examples under the intended public rule IDs.
+- The adversarial review found and resolved one closing-position fixture regression; the follow-up review found no blockers.
+
+# Next steps
+
+- Commit and push the feature branch.
+- Merge after CI passes.
+- Publish and install `slopless@0.2.32`.

--- a/behavior/fixtures/textlint-rules/cases/semantic-thinness/hits.md
+++ b/behavior/fixtures/textlint-rules/cases/semantic-thinness/hits.md
@@ -266,6 +266,30 @@ The review basically put a number on that.
 
 That's the shift.
 
+That shift changed everything.
+
+This shift changes everything.
+
+The shift transformed everything.
+
+That change reshaped everything.
+
+This decision changed the whole picture.
+
+The move made all the difference.
+
+That experience changed everything.
+
+This result transformed everything.
+
+The decision reshapes everything.
+
+That move changed the whole picture.
+
+The change made all the difference.
+
+The experience changed everything.
+
 The market is quietly shifting.
 
 The industry is subtly evolving.

--- a/behavior/fixtures/textlint-rules/cases/semantic-thinness/no-hits.md
+++ b/behavior/fixtures/textlint-rules/cases/semantic-thinness/no-hits.md
@@ -328,6 +328,30 @@ The model had quietly changed from version 2 to version 3.
 
 The system shifted quietly after the operator replaced the worn bearing.
 
+That shift changed every API route from version 1 to version 2.
+
+That shift changed everything because it removed the last failing repayment case.
+
+That shift changed everything in the gearbox by moving the input shaft 4 millimeters.
+
+The shift transformed 400 records per second.
+
+This decision changed the repayment date to July 1.
+
+The move made a 14 percent difference in missed appointments.
+
+That experience changed every scheduled interview.
+
+The shift changed the whole picture in the dashboard by adding regional totals.
+
+This result transformed the image by rotating every pixel 90 degrees.
+
+The change reshaped every column in the export.
+
+The decision made all the difference because it funded the second clinic.
+
+The experience changed everything after the storm closed the bridge at 8:13.
+
 That is the point guard selected in the draft.
 
 That is the report prepared for the board.

--- a/behavior/fixtures/textlint-rules/cases/syntactic-patterns/hits.md
+++ b/behavior/fixtures/textlint-rules/cases/syntactic-patterns/hits.md
@@ -1495,3 +1495,39 @@ Here is the interesting angle.
 This is the obvious catch.
 
 Here is an important aspect.
+
+Some of the biggest shifts in leadership come from experiences outside work.
+
+Some of the greatest lessons in business come from failure.
+
+Many of the deepest insights in leadership emerge from adversity.
+
+Some of the best ideas in design come from unexpected places.
+
+Some of the strongest skills in management grow from setbacks.
+
+Many of the most valuable lessons in life come from discomfort.
+
+Some of the most meaningful changes in careers start with failure.
+
+Some of the biggest breakthroughs in technology emerge from challenges.
+
+Many of the most useful insights in writing come from ordinary moments.
+
+Some of the greatest improvements in strategy begin with adversity.
+
+Some of the best decisions in business came from experience.
+
+Many of the strongest skills in leadership grew from experiences outside work.
+
+Some of the biggest advances in technology emerged from failures.
+
+Some of the deepest lessons in growth started with setbacks.
+
+Many of the most important ideas in management began with discomfort.
+
+Some of the greatest shifts in work come from elsewhere.
+
+Many of the biggest changes in life grow from challenges.
+
+Some of the most valuable breakthroughs come from unexpected places.

--- a/behavior/fixtures/textlint-rules/cases/syntactic-patterns/no-hits.md
+++ b/behavior/fixtures/textlint-rules/cases/syntactic-patterns/no-hits.md
@@ -593,3 +593,39 @@ That is a remarkable piece of Renaissance sculpture.
 This is the important point on the map.
 
 Here is the key element in the periodic table.
+
+Some of the largest tectonic shifts in Chile came from the 1960 earthquake.
+
+Some of the biggest shifts in the survey occurred after the 2024 tax change.
+
+Three leadership shifts came from the merger.
+
+Some of the best ideas in design came from 18 customer interviews.
+
+Some of the most important lessons in the manual come from chapter 4.
+
+Some of the biggest changes in the API came from the version 3 migration.
+
+Many of the strongest skills in the cohort improved after a 12-week course.
+
+Some of the greatest advances in battery chemistry came from lithium iron phosphate cathodes.
+
+Some of the deepest insights in the report came from interviews with 42 users.
+
+Some of the best decisions in the project came from the audit on May 4.
+
+Some of the largest shifts in the fault line came from the earthquake.
+
+The biggest shift in leadership came from the acquisition.
+
+Some leadership changes came from the merger.
+
+Some of the biggest shifts outside work affected leadership.
+
+Some of the most valuable lessons in life were taught by her grandmother.
+
+Many of the best ideas in design came from sketches made by Elena.
+
+Some of the strongest skills in management came from the 2025 training program.
+
+Some of the deepest changes in careers came from layoffs at Acme in March.

--- a/behavior/fixtures/textlint-rules/corpus/engineering-review.md
+++ b/behavior/fixtures/textlint-rules/corpus/engineering-review.md
@@ -1153,3 +1153,43 @@ The final records named the measured transition. This marks a 4-point shift in t
 The grammatical controls kept the same verb forms but supplied measurements, causes, or before-and-after states. The platform subtly evolves after each weekly model update. The market quietly shifted 3 points after the rate announcement. The web was silently transforming 40 records per second.
 
 The final controls named both endpoints or the physical cause. The industry has quietly changed from annual contracts to monthly plans. The model had quietly changed from version 2 to version 3. The system shifted quietly after the operator replaced the worn bearing.
+
+## Total-impact claims
+
+The strategy draft repeatedly announced total consequences without naming any consequence. That shift changed everything. This shift changes everything. The shift transformed everything. That change reshaped everything.
+
+The next section repeated the claim with decisions and moves. This decision changed the whole picture. The move made all the difference. That experience changed everything. This result transformed everything.
+
+The closing paragraph varied tense but supplied no result. The decision reshapes everything. That move changed the whole picture. The change made all the difference. The experience changed everything.
+
+The engineering notes used similar words for bounded changes. That shift changed every API route from version 1 to version 2. That shift changed everything because it removed the last failing repayment case. That shift changed everything in the gearbox by moving the input shaft 4 millimeters. The shift transformed 400 records per second.
+
+The operations record supplied dates and measurements. This decision changed the repayment date to July 1. The move made a 14 percent difference in missed appointments. That experience changed every scheduled interview. The shift changed the whole picture in the dashboard by adding regional totals.
+
+The last controls named the object, mechanism, or cause. This result transformed the image by rotating every pixel 90 degrees. The change reshaped every column in the export. The decision made all the difference because it funded the second clinic. The experience changed everything after the storm closed the bridge at 8:13.
+
+## Vague sources of important change
+
+The leadership draft generalized from unnamed experiences and abstract sources. Some of the biggest shifts in leadership come from experiences outside work. Some of the greatest lessons in business come from failure. Many of the deepest insights in leadership emerge from adversity.
+
+The design and management sections used the same frame. Some of the best ideas in design come from unexpected places. Some of the strongest skills in management grow from setbacks. Many of the most valuable lessons in life come from discomfort.
+
+The career and technology sections continued without naming evidence. Some of the most meaningful changes in careers start with failure. Some of the biggest breakthroughs in technology emerge from challenges. Many of the most useful insights in writing come from ordinary moments.
+
+The conclusion varied the abstract outcome. Some of the greatest improvements in strategy begin with adversity. Some of the best decisions in business came from experience. Many of the strongest skills in leadership grew from experiences outside work.
+
+The last claims changed tense and source words. Some of the biggest advances in technology emerged from failures. Some of the deepest lessons in growth started with setbacks. Many of the most important ideas in management began with discomfort.
+
+The final paragraph removed the domain from one claim but retained the same vague source. Some of the greatest shifts in work come from elsewhere. Many of the biggest changes in life grow from challenges. Some of the most valuable breakthroughs come from unexpected places.
+
+The review controls named measurements, events, people, records, or narrower grammar. Some of the largest tectonic shifts in Chile came from the 1960 earthquake. Some of the biggest shifts in the survey occurred after the 2024 tax change. Three leadership shifts came from the merger.
+
+The next controls named the evidence source. Some of the best ideas in design came from 18 customer interviews. Some of the most important lessons in the manual come from chapter 4. Some of the biggest changes in the API came from the version 3 migration.
+
+The training and research controls supplied specific interventions or materials. Many of the strongest skills in the cohort improved after a 12-week course. Some of the greatest advances in battery chemistry came from lithium iron phosphate cathodes. Some of the deepest insights in the report came from interviews with 42 users.
+
+The project and geology records named events and dates. Some of the best decisions in the project came from the audit on May 4. Some of the largest shifts in the fault line came from the earthquake. The biggest shift in leadership came from the acquisition.
+
+The grammatical controls omitted the required frame or reversed its parts. Some leadership changes came from the merger. Some of the biggest shifts outside work affected leadership.
+
+The final records named people, programs, and employers. Some of the most valuable lessons in life were taught by her grandmother. Many of the best ideas in design came from sketches made by Elena. Some of the strongest skills in management came from the 2025 training program. Some of the deepest changes in careers came from layoffs at Acme in March.

--- a/behavior/fixtures/textlint-rules/corpus/engineering-review.preserve.json
+++ b/behavior/fixtures/textlint-rules/corpus/engineering-review.preserve.json
@@ -4186,14 +4186,14 @@
       "family": "semantic-thinness",
       "bucket": "no-hits",
       "source": "cases/semantic-thinness/no-hits.md",
-      "line": 331
+      "line": 355
     },
     {
       "text": "That is the report prepared for the board.",
       "family": "semantic-thinness",
       "bucket": "no-hits",
       "source": "cases/semantic-thinness/no-hits.md",
-      "line": 333
+      "line": 357
     },
     {
       "text": "It can't start because the battery voltage is below 11 volts.",
@@ -4529,140 +4529,140 @@
       "family": "semantic-thinness",
       "bucket": "hits",
       "source": "cases/semantic-thinness/hits.md",
-      "line": 269
+      "line": 293
     },
     {
       "text": "The industry is subtly evolving.",
       "family": "semantic-thinness",
       "bucket": "hits",
       "source": "cases/semantic-thinness/hits.md",
-      "line": 271
+      "line": 295
     },
     {
       "text": "Search is gradually changing.",
       "family": "semantic-thinness",
       "bucket": "hits",
       "source": "cases/semantic-thinness/hits.md",
-      "line": 273
+      "line": 297
     },
     {
       "text": "The web is silently transforming.",
       "family": "semantic-thinness",
       "bucket": "hits",
       "source": "cases/semantic-thinness/hits.md",
-      "line": 275
+      "line": 299
     },
     {
       "text": "The landscape is steadily reshaping.",
       "family": "semantic-thinness",
       "bucket": "hits",
       "source": "cases/semantic-thinness/hits.md",
-      "line": 277
+      "line": 301
     },
     {
       "text": "The platform is almost invisibly redefining.",
       "family": "semantic-thinness",
       "bucket": "hits",
       "source": "cases/semantic-thinness/hits.md",
-      "line": 279
+      "line": 303
     },
     {
       "text": "This quietly changes everything.",
       "family": "semantic-thinness",
       "bucket": "hits",
       "source": "cases/semantic-thinness/hits.md",
-      "line": 281
+      "line": 305
     },
     {
       "text": "That subtly reshapes everything.",
       "family": "semantic-thinness",
       "bucket": "hits",
       "source": "cases/semantic-thinness/hits.md",
-      "line": 283
+      "line": 307
     },
     {
       "text": "A quiet shift is underway.",
       "family": "semantic-thinness",
       "bucket": "hits",
       "source": "cases/semantic-thinness/hits.md",
-      "line": 285
+      "line": 309
     },
     {
       "text": "The subtle shift is happening.",
       "family": "semantic-thinness",
       "bucket": "hits",
       "source": "cases/semantic-thinness/hits.md",
-      "line": 287
+      "line": 311
     },
     {
       "text": "This broader shift has begun.",
       "family": "semantic-thinness",
       "bucket": "hits",
       "source": "cases/semantic-thinness/hits.md",
-      "line": 289
+      "line": 313
     },
     {
       "text": "A meaningful shift is already here.",
       "family": "semantic-thinness",
       "bucket": "hits",
       "source": "cases/semantic-thinness/hits.md",
-      "line": 291
+      "line": 315
     },
     {
       "text": "The important shift is easy to miss.",
       "family": "semantic-thinness",
       "bucket": "hits",
       "source": "cases/semantic-thinness/hits.md",
-      "line": 293
+      "line": 317
     },
     {
       "text": "The fundamental shift is hard to ignore.",
       "family": "semantic-thinness",
       "bucket": "hits",
       "source": "cases/semantic-thinness/hits.md",
-      "line": 295
+      "line": 319
     },
     {
       "text": "The structural shift matters.",
       "family": "semantic-thinness",
       "bucket": "hits",
       "source": "cases/semantic-thinness/hits.md",
-      "line": 297
+      "line": 321
     },
     {
       "text": "The profound shift changes everything.",
       "family": "semantic-thinness",
       "bucket": "hits",
       "source": "cases/semantic-thinness/hits.md",
-      "line": 299
+      "line": 323
     },
     {
       "text": "This marks a broader shift.",
       "family": "semantic-thinness",
       "bucket": "hits",
       "source": "cases/semantic-thinness/hits.md",
-      "line": 301
+      "line": 325
     },
     {
       "text": "That signals a seismic shift.",
       "family": "semantic-thinness",
       "bucket": "hits",
       "source": "cases/semantic-thinness/hits.md",
-      "line": 303
+      "line": 327
     },
     {
       "text": "This represents a meaningful shift.",
       "family": "semantic-thinness",
       "bucket": "hits",
       "source": "cases/semantic-thinness/hits.md",
-      "line": 305
+      "line": 329
     },
     {
       "text": "This reflects a notable shift.",
       "family": "semantic-thinness",
       "bucket": "hits",
       "source": "cases/semantic-thinness/hits.md",
-      "line": 307
+      "line": 331
     },
     {
       "text": "The nurse carefully shifted the tray toward the patient.",
@@ -4781,42 +4781,42 @@
       "family": "semantic-thinness",
       "bucket": "hits",
       "source": "cases/semantic-thinness/hits.md",
-      "line": 309
+      "line": 333
     },
     {
       "text": "The market quietly shifted.",
       "family": "semantic-thinness",
       "bucket": "hits",
       "source": "cases/semantic-thinness/hits.md",
-      "line": 311
+      "line": 335
     },
     {
       "text": "The web was silently transforming.",
       "family": "semantic-thinness",
       "bucket": "hits",
       "source": "cases/semantic-thinness/hits.md",
-      "line": 313
+      "line": 337
     },
     {
       "text": "The industry has quietly changed.",
       "family": "semantic-thinness",
       "bucket": "hits",
       "source": "cases/semantic-thinness/hits.md",
-      "line": 315
+      "line": 339
     },
     {
       "text": "The model had quietly changed.",
       "family": "semantic-thinness",
       "bucket": "hits",
       "source": "cases/semantic-thinness/hits.md",
-      "line": 317
+      "line": 341
     },
     {
       "text": "The system shifted quietly.",
       "family": "semantic-thinness",
       "bucket": "hits",
       "source": "cases/semantic-thinness/hits.md",
-      "line": 319
+      "line": 343
     },
     {
       "text": "The platform subtly evolves after each weekly model update.",
@@ -4859,6 +4859,426 @@
       "bucket": "no-hits",
       "source": "cases/semantic-thinness/no-hits.md",
       "line": 329
+    },
+    {
+      "text": "That shift changed everything.",
+      "family": "semantic-thinness",
+      "bucket": "hits",
+      "source": "cases/semantic-thinness/hits.md",
+      "line": 269
+    },
+    {
+      "text": "This shift changes everything.",
+      "family": "semantic-thinness",
+      "bucket": "hits",
+      "source": "cases/semantic-thinness/hits.md",
+      "line": 271
+    },
+    {
+      "text": "The shift transformed everything.",
+      "family": "semantic-thinness",
+      "bucket": "hits",
+      "source": "cases/semantic-thinness/hits.md",
+      "line": 273
+    },
+    {
+      "text": "That change reshaped everything.",
+      "family": "semantic-thinness",
+      "bucket": "hits",
+      "source": "cases/semantic-thinness/hits.md",
+      "line": 275
+    },
+    {
+      "text": "This decision changed the whole picture.",
+      "family": "semantic-thinness",
+      "bucket": "hits",
+      "source": "cases/semantic-thinness/hits.md",
+      "line": 277
+    },
+    {
+      "text": "The move made all the difference.",
+      "family": "semantic-thinness",
+      "bucket": "hits",
+      "source": "cases/semantic-thinness/hits.md",
+      "line": 279
+    },
+    {
+      "text": "That experience changed everything.",
+      "family": "semantic-thinness",
+      "bucket": "hits",
+      "source": "cases/semantic-thinness/hits.md",
+      "line": 281
+    },
+    {
+      "text": "This result transformed everything.",
+      "family": "semantic-thinness",
+      "bucket": "hits",
+      "source": "cases/semantic-thinness/hits.md",
+      "line": 283
+    },
+    {
+      "text": "The decision reshapes everything.",
+      "family": "semantic-thinness",
+      "bucket": "hits",
+      "source": "cases/semantic-thinness/hits.md",
+      "line": 285
+    },
+    {
+      "text": "That move changed the whole picture.",
+      "family": "semantic-thinness",
+      "bucket": "hits",
+      "source": "cases/semantic-thinness/hits.md",
+      "line": 287
+    },
+    {
+      "text": "The change made all the difference.",
+      "family": "semantic-thinness",
+      "bucket": "hits",
+      "source": "cases/semantic-thinness/hits.md",
+      "line": 289
+    },
+    {
+      "text": "The experience changed everything.",
+      "family": "semantic-thinness",
+      "bucket": "hits",
+      "source": "cases/semantic-thinness/hits.md",
+      "line": 291
+    },
+    {
+      "text": "That shift changed every API route from version 1 to version 2.",
+      "family": "semantic-thinness",
+      "bucket": "no-hits",
+      "source": "cases/semantic-thinness/no-hits.md",
+      "line": 331
+    },
+    {
+      "text": "That shift changed everything because it removed the last failing repayment case.",
+      "family": "semantic-thinness",
+      "bucket": "no-hits",
+      "source": "cases/semantic-thinness/no-hits.md",
+      "line": 333
+    },
+    {
+      "text": "That shift changed everything in the gearbox by moving the input shaft 4 millimeters.",
+      "family": "semantic-thinness",
+      "bucket": "no-hits",
+      "source": "cases/semantic-thinness/no-hits.md",
+      "line": 335
+    },
+    {
+      "text": "The shift transformed 400 records per second.",
+      "family": "semantic-thinness",
+      "bucket": "no-hits",
+      "source": "cases/semantic-thinness/no-hits.md",
+      "line": 337
+    },
+    {
+      "text": "This decision changed the repayment date to July 1.",
+      "family": "semantic-thinness",
+      "bucket": "no-hits",
+      "source": "cases/semantic-thinness/no-hits.md",
+      "line": 339
+    },
+    {
+      "text": "The move made a 14 percent difference in missed appointments.",
+      "family": "semantic-thinness",
+      "bucket": "no-hits",
+      "source": "cases/semantic-thinness/no-hits.md",
+      "line": 341
+    },
+    {
+      "text": "That experience changed every scheduled interview.",
+      "family": "semantic-thinness",
+      "bucket": "no-hits",
+      "source": "cases/semantic-thinness/no-hits.md",
+      "line": 343
+    },
+    {
+      "text": "The shift changed the whole picture in the dashboard by adding regional totals.",
+      "family": "semantic-thinness",
+      "bucket": "no-hits",
+      "source": "cases/semantic-thinness/no-hits.md",
+      "line": 345
+    },
+    {
+      "text": "This result transformed the image by rotating every pixel 90 degrees.",
+      "family": "semantic-thinness",
+      "bucket": "no-hits",
+      "source": "cases/semantic-thinness/no-hits.md",
+      "line": 347
+    },
+    {
+      "text": "The change reshaped every column in the export.",
+      "family": "semantic-thinness",
+      "bucket": "no-hits",
+      "source": "cases/semantic-thinness/no-hits.md",
+      "line": 349
+    },
+    {
+      "text": "The decision made all the difference because it funded the second clinic.",
+      "family": "semantic-thinness",
+      "bucket": "no-hits",
+      "source": "cases/semantic-thinness/no-hits.md",
+      "line": 351
+    },
+    {
+      "text": "The experience changed everything after the storm closed the bridge at 8:13.",
+      "family": "semantic-thinness",
+      "bucket": "no-hits",
+      "source": "cases/semantic-thinness/no-hits.md",
+      "line": 353
+    },
+    {
+      "text": "Some of the biggest shifts in leadership come from experiences outside work.",
+      "family": "syntactic-patterns",
+      "bucket": "hits",
+      "source": "cases/syntactic-patterns/hits.md",
+      "line": 1499
+    },
+    {
+      "text": "Some of the greatest lessons in business come from failure.",
+      "family": "syntactic-patterns",
+      "bucket": "hits",
+      "source": "cases/syntactic-patterns/hits.md",
+      "line": 1501
+    },
+    {
+      "text": "Many of the deepest insights in leadership emerge from adversity.",
+      "family": "syntactic-patterns",
+      "bucket": "hits",
+      "source": "cases/syntactic-patterns/hits.md",
+      "line": 1503
+    },
+    {
+      "text": "Some of the best ideas in design come from unexpected places.",
+      "family": "syntactic-patterns",
+      "bucket": "hits",
+      "source": "cases/syntactic-patterns/hits.md",
+      "line": 1505
+    },
+    {
+      "text": "Some of the strongest skills in management grow from setbacks.",
+      "family": "syntactic-patterns",
+      "bucket": "hits",
+      "source": "cases/syntactic-patterns/hits.md",
+      "line": 1507
+    },
+    {
+      "text": "Many of the most valuable lessons in life come from discomfort.",
+      "family": "syntactic-patterns",
+      "bucket": "hits",
+      "source": "cases/syntactic-patterns/hits.md",
+      "line": 1509
+    },
+    {
+      "text": "Some of the most meaningful changes in careers start with failure.",
+      "family": "syntactic-patterns",
+      "bucket": "hits",
+      "source": "cases/syntactic-patterns/hits.md",
+      "line": 1511
+    },
+    {
+      "text": "Some of the biggest breakthroughs in technology emerge from challenges.",
+      "family": "syntactic-patterns",
+      "bucket": "hits",
+      "source": "cases/syntactic-patterns/hits.md",
+      "line": 1513
+    },
+    {
+      "text": "Many of the most useful insights in writing come from ordinary moments.",
+      "family": "syntactic-patterns",
+      "bucket": "hits",
+      "source": "cases/syntactic-patterns/hits.md",
+      "line": 1515
+    },
+    {
+      "text": "Some of the greatest improvements in strategy begin with adversity.",
+      "family": "syntactic-patterns",
+      "bucket": "hits",
+      "source": "cases/syntactic-patterns/hits.md",
+      "line": 1517
+    },
+    {
+      "text": "Some of the best decisions in business came from experience.",
+      "family": "syntactic-patterns",
+      "bucket": "hits",
+      "source": "cases/syntactic-patterns/hits.md",
+      "line": 1519
+    },
+    {
+      "text": "Many of the strongest skills in leadership grew from experiences outside work.",
+      "family": "syntactic-patterns",
+      "bucket": "hits",
+      "source": "cases/syntactic-patterns/hits.md",
+      "line": 1521
+    },
+    {
+      "text": "Some of the biggest advances in technology emerged from failures.",
+      "family": "syntactic-patterns",
+      "bucket": "hits",
+      "source": "cases/syntactic-patterns/hits.md",
+      "line": 1523
+    },
+    {
+      "text": "Some of the deepest lessons in growth started with setbacks.",
+      "family": "syntactic-patterns",
+      "bucket": "hits",
+      "source": "cases/syntactic-patterns/hits.md",
+      "line": 1525
+    },
+    {
+      "text": "Many of the most important ideas in management began with discomfort.",
+      "family": "syntactic-patterns",
+      "bucket": "hits",
+      "source": "cases/syntactic-patterns/hits.md",
+      "line": 1527
+    },
+    {
+      "text": "Some of the greatest shifts in work come from elsewhere.",
+      "family": "syntactic-patterns",
+      "bucket": "hits",
+      "source": "cases/syntactic-patterns/hits.md",
+      "line": 1529
+    },
+    {
+      "text": "Many of the biggest changes in life grow from challenges.",
+      "family": "syntactic-patterns",
+      "bucket": "hits",
+      "source": "cases/syntactic-patterns/hits.md",
+      "line": 1531
+    },
+    {
+      "text": "Some of the most valuable breakthroughs come from unexpected places.",
+      "family": "syntactic-patterns",
+      "bucket": "hits",
+      "source": "cases/syntactic-patterns/hits.md",
+      "line": 1533
+    },
+    {
+      "text": "Some of the largest tectonic shifts in Chile came from the 1960 earthquake.",
+      "family": "syntactic-patterns",
+      "bucket": "no-hits",
+      "source": "cases/syntactic-patterns/no-hits.md",
+      "line": 597
+    },
+    {
+      "text": "Some of the biggest shifts in the survey occurred after the 2024 tax change.",
+      "family": "syntactic-patterns",
+      "bucket": "no-hits",
+      "source": "cases/syntactic-patterns/no-hits.md",
+      "line": 599
+    },
+    {
+      "text": "Three leadership shifts came from the merger.",
+      "family": "syntactic-patterns",
+      "bucket": "no-hits",
+      "source": "cases/syntactic-patterns/no-hits.md",
+      "line": 601
+    },
+    {
+      "text": "Some of the best ideas in design came from 18 customer interviews.",
+      "family": "syntactic-patterns",
+      "bucket": "no-hits",
+      "source": "cases/syntactic-patterns/no-hits.md",
+      "line": 603
+    },
+    {
+      "text": "Some of the most important lessons in the manual come from chapter 4.",
+      "family": "syntactic-patterns",
+      "bucket": "no-hits",
+      "source": "cases/syntactic-patterns/no-hits.md",
+      "line": 605
+    },
+    {
+      "text": "Some of the biggest changes in the API came from the version 3 migration.",
+      "family": "syntactic-patterns",
+      "bucket": "no-hits",
+      "source": "cases/syntactic-patterns/no-hits.md",
+      "line": 607
+    },
+    {
+      "text": "Many of the strongest skills in the cohort improved after a 12-week course.",
+      "family": "syntactic-patterns",
+      "bucket": "no-hits",
+      "source": "cases/syntactic-patterns/no-hits.md",
+      "line": 609
+    },
+    {
+      "text": "Some of the greatest advances in battery chemistry came from lithium iron phosphate cathodes.",
+      "family": "syntactic-patterns",
+      "bucket": "no-hits",
+      "source": "cases/syntactic-patterns/no-hits.md",
+      "line": 611
+    },
+    {
+      "text": "Some of the deepest insights in the report came from interviews with 42 users.",
+      "family": "syntactic-patterns",
+      "bucket": "no-hits",
+      "source": "cases/syntactic-patterns/no-hits.md",
+      "line": 613
+    },
+    {
+      "text": "Some of the best decisions in the project came from the audit on May 4.",
+      "family": "syntactic-patterns",
+      "bucket": "no-hits",
+      "source": "cases/syntactic-patterns/no-hits.md",
+      "line": 615
+    },
+    {
+      "text": "Some of the largest shifts in the fault line came from the earthquake.",
+      "family": "syntactic-patterns",
+      "bucket": "no-hits",
+      "source": "cases/syntactic-patterns/no-hits.md",
+      "line": 617
+    },
+    {
+      "text": "The biggest shift in leadership came from the acquisition.",
+      "family": "syntactic-patterns",
+      "bucket": "no-hits",
+      "source": "cases/syntactic-patterns/no-hits.md",
+      "line": 619
+    },
+    {
+      "text": "Some leadership changes came from the merger.",
+      "family": "syntactic-patterns",
+      "bucket": "no-hits",
+      "source": "cases/syntactic-patterns/no-hits.md",
+      "line": 621
+    },
+    {
+      "text": "Some of the biggest shifts outside work affected leadership.",
+      "family": "syntactic-patterns",
+      "bucket": "no-hits",
+      "source": "cases/syntactic-patterns/no-hits.md",
+      "line": 623
+    },
+    {
+      "text": "Some of the most valuable lessons in life were taught by her grandmother.",
+      "family": "syntactic-patterns",
+      "bucket": "no-hits",
+      "source": "cases/syntactic-patterns/no-hits.md",
+      "line": 625
+    },
+    {
+      "text": "Many of the best ideas in design came from sketches made by Elena.",
+      "family": "syntactic-patterns",
+      "bucket": "no-hits",
+      "source": "cases/syntactic-patterns/no-hits.md",
+      "line": 627
+    },
+    {
+      "text": "Some of the strongest skills in management came from the 2025 training program.",
+      "family": "syntactic-patterns",
+      "bucket": "no-hits",
+      "source": "cases/syntactic-patterns/no-hits.md",
+      "line": 629
+    },
+    {
+      "text": "Some of the deepest changes in careers came from layoffs at Acme in March.",
+      "family": "syntactic-patterns",
+      "bucket": "no-hits",
+      "source": "cases/syntactic-patterns/no-hits.md",
+      "line": 631
     }
   ]
 }

--- a/behavior/golden/textlint-rules-cases-semantic-thinness/approved.meta.json
+++ b/behavior/golden/textlint-rules-cases-semantic-thinness/approved.meta.json
@@ -1,22 +1,23 @@
 {
   "suite": "textlint-rules-cases-semantic-thinness",
   "kind": "approved",
-  "run_id": "2026-07-24T22-36-31.151764Z-04547efb",
-  "run_commit": "ac067f7",
+  "run_id": "2026-07-28T11-42-24.634723Z-04547efb",
+  "run_commit": "4d6c658",
   "working_tree": "dirty",
-  "recorded_at": "2026-07-24T22:36:31.151764Z",
-  "fixture_hash": "sha256:cdd72aebaed2528dd027df319b052870ae5dfafd72157b6b57fc4c5564339d75",
+  "recorded_at": "2026-07-28T11:42:24.634723Z",
+  "fixture_hash": "sha256:3b3451bb94094707950dd914ce12540f9edd28588f3845a98e38f0e716d5ed03",
   "manifest_hash": "sha256:04547efbb13157ee3d8ef18dda767231fd63d3f9cc27c15317cf28c5f0583e7b",
   "tool_version": "0.1.8",
   "output_schema_version": "1",
   "fixtures": [
     {
       "path": "behavior/fixtures/textlint-rules/cases/semantic-thinness/hits.md",
-      "sha256": "sha256:72dc704ac44291602591badf584bf9791bcd3c0aebcfdd961b81e4c79e90ce38"
+      "sha256": "sha256:a440b288538b7a5755b4fe37db9a0afc1b0199f88e74bfe20d7f13e6978e0626"
     },
     {
       "path": "behavior/fixtures/textlint-rules/cases/semantic-thinness/no-hits.md",
-      "sha256": "sha256:6b8fd794ae57e5bbbe2cde072d9bf773dcb25ca4c04f2ec7adb8a4b982fd6e32"
+      "sha256": "sha256:e8d3133d1af81d0b005e95273b1b23a94b8eab8619087db70a33f7566709ac1d"
     }
-  ]
+  ],
+  "comment": "Restore closing-position boilerplate finding after adding total-impact controls."
 }

--- a/behavior/golden/textlint-rules-cases-semantic-thinness/approved.normalized.json
+++ b/behavior/golden/textlint-rules-cases-semantic-thinness/approved.normalized.json
@@ -16,7 +16,7 @@
             "line": 1
           }
         },
-        "message": "Coleman-Liau is 13.03. Keep it at 12 or lower.",
+        "message": "Coleman-Liau is 13.49. Keep it at 12 or lower.",
         "range": [
           0,
           1
@@ -39,7 +39,7 @@
             "line": 1
           }
         },
-        "message": "Flesch Reading Ease is -347.39. Keep it at 61 or higher.",
+        "message": "Flesch Reading Ease is -366.37. Keep it at 61 or higher.",
         "range": [
           0,
           1
@@ -62,7 +62,7 @@
             "line": 1
           }
         },
-        "message": "Gunning Fog is 171.16. Keep it at 12 or lower.",
+        "message": "Gunning Fog is 178.52. Keep it at 12 or lower.",
         "range": [
           0,
           1
@@ -3642,7 +3642,7 @@
         "line": 269,
         "loc": {
           "end": {
-            "column": 32,
+            "column": 31,
             "line": 269
           },
           "start": {
@@ -3650,10 +3650,286 @@
             "line": 269
           }
         },
-        "message": "Semantic thinness (something-shifted): Catch vague change declarations that say something shifted, changed, moved, or crossed a line without naming the concrete change. Matched template: {diffuseSubject} {progressiveAuxiliary} {weakMannerAdverb} {progressiveChange}.",
+        "message": "Semantic thinness (hollow-significance): Catch lines that assert importance, sticking power, or consequence without naming a concrete referent or result. Matched template: {totalImpactSubject} {totalImpactVerb} {totalImpactObject}.",
         "range": [
           6106,
-          6137
+          6136
+        ],
+        "ruleId": "semantic-thinness",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 6138,
+        "line": 271,
+        "loc": {
+          "end": {
+            "column": 31,
+            "line": 271
+          },
+          "start": {
+            "column": 1,
+            "line": 271
+          }
+        },
+        "message": "Semantic thinness (hollow-significance): Catch lines that assert importance, sticking power, or consequence without naming a concrete referent or result. Matched template: {totalImpactSubject} {totalImpactVerb} {totalImpactObject}.",
+        "range": [
+          6138,
+          6168
+        ],
+        "ruleId": "semantic-thinness",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 6170,
+        "line": 273,
+        "loc": {
+          "end": {
+            "column": 34,
+            "line": 273
+          },
+          "start": {
+            "column": 1,
+            "line": 273
+          }
+        },
+        "message": "Semantic thinness (hollow-significance): Catch lines that assert importance, sticking power, or consequence without naming a concrete referent or result. Matched template: {totalImpactSubject} {totalImpactVerb} {totalImpactObject}.",
+        "range": [
+          6170,
+          6203
+        ],
+        "ruleId": "semantic-thinness",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 6205,
+        "line": 275,
+        "loc": {
+          "end": {
+            "column": 33,
+            "line": 275
+          },
+          "start": {
+            "column": 1,
+            "line": 275
+          }
+        },
+        "message": "Semantic thinness (hollow-significance): Catch lines that assert importance, sticking power, or consequence without naming a concrete referent or result. Matched template: {totalImpactSubject} {totalImpactVerb} {totalImpactObject}.",
+        "range": [
+          6205,
+          6237
+        ],
+        "ruleId": "semantic-thinness",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 6239,
+        "line": 277,
+        "loc": {
+          "end": {
+            "column": 41,
+            "line": 277
+          },
+          "start": {
+            "column": 1,
+            "line": 277
+          }
+        },
+        "message": "Semantic thinness (hollow-significance): Catch lines that assert importance, sticking power, or consequence without naming a concrete referent or result. Matched template: {totalImpactSubject} {totalImpactVerb} {totalImpactObject}.",
+        "range": [
+          6239,
+          6279
+        ],
+        "ruleId": "semantic-thinness",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 6281,
+        "line": 279,
+        "loc": {
+          "end": {
+            "column": 34,
+            "line": 279
+          },
+          "start": {
+            "column": 1,
+            "line": 279
+          }
+        },
+        "message": "Semantic thinness (hollow-significance): Catch lines that assert importance, sticking power, or consequence without naming a concrete referent or result. Matched template: {totalImpactSubject} {differenceVerb} all the difference.",
+        "range": [
+          6281,
+          6314
+        ],
+        "ruleId": "semantic-thinness",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 6316,
+        "line": 281,
+        "loc": {
+          "end": {
+            "column": 36,
+            "line": 281
+          },
+          "start": {
+            "column": 1,
+            "line": 281
+          }
+        },
+        "message": "Semantic thinness (hollow-significance): Catch lines that assert importance, sticking power, or consequence without naming a concrete referent or result. Matched template: {totalImpactSubject} {totalImpactVerb} {totalImpactObject}.",
+        "range": [
+          6316,
+          6351
+        ],
+        "ruleId": "semantic-thinness",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 6353,
+        "line": 283,
+        "loc": {
+          "end": {
+            "column": 36,
+            "line": 283
+          },
+          "start": {
+            "column": 1,
+            "line": 283
+          }
+        },
+        "message": "Semantic thinness (hollow-significance): Catch lines that assert importance, sticking power, or consequence without naming a concrete referent or result. Matched template: {totalImpactSubject} {totalImpactVerb} {totalImpactObject}.",
+        "range": [
+          6353,
+          6388
+        ],
+        "ruleId": "semantic-thinness",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 6390,
+        "line": 285,
+        "loc": {
+          "end": {
+            "column": 34,
+            "line": 285
+          },
+          "start": {
+            "column": 1,
+            "line": 285
+          }
+        },
+        "message": "Semantic thinness (hollow-significance): Catch lines that assert importance, sticking power, or consequence without naming a concrete referent or result. Matched template: {totalImpactSubject} {totalImpactVerb} {totalImpactObject}.",
+        "range": [
+          6390,
+          6423
+        ],
+        "ruleId": "semantic-thinness",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 6425,
+        "line": 287,
+        "loc": {
+          "end": {
+            "column": 37,
+            "line": 287
+          },
+          "start": {
+            "column": 1,
+            "line": 287
+          }
+        },
+        "message": "Semantic thinness (hollow-significance): Catch lines that assert importance, sticking power, or consequence without naming a concrete referent or result. Matched template: {totalImpactSubject} {totalImpactVerb} {totalImpactObject}.",
+        "range": [
+          6425,
+          6461
+        ],
+        "ruleId": "semantic-thinness",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 6463,
+        "line": 289,
+        "loc": {
+          "end": {
+            "column": 36,
+            "line": 289
+          },
+          "start": {
+            "column": 1,
+            "line": 289
+          }
+        },
+        "message": "Semantic thinness (hollow-significance): Catch lines that assert importance, sticking power, or consequence without naming a concrete referent or result. Matched template: {totalImpactSubject} {differenceVerb} all the difference.",
+        "range": [
+          6463,
+          6498
+        ],
+        "ruleId": "semantic-thinness",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 6500,
+        "line": 291,
+        "loc": {
+          "end": {
+            "column": 35,
+            "line": 291
+          },
+          "start": {
+            "column": 1,
+            "line": 291
+          }
+        },
+        "message": "Semantic thinness (hollow-significance): Catch lines that assert importance, sticking power, or consequence without naming a concrete referent or result. Matched template: {totalImpactSubject} {totalImpactVerb} {totalImpactObject}.",
+        "range": [
+          6500,
+          6534
+        ],
+        "ruleId": "semantic-thinness",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 6536,
+        "line": 293,
+        "loc": {
+          "end": {
+            "column": 32,
+            "line": 293
+          },
+          "start": {
+            "column": 1,
+            "line": 293
+          }
+        },
+        "message": "Semantic thinness (something-shifted): Catch vague change declarations that say something shifted, changed, moved, or crossed a line without naming the concrete change. Matched template: {diffuseSubject} {progressiveAuxiliary} {weakMannerAdverb} {progressiveChange}.",
+        "range": [
+          6536,
+          6567
         ],
         "ruleId": "semantic-thinness",
         "severity": 2,
@@ -3673,22 +3949,22 @@
           },
           "severity": 1
         },
-        "index": 6120,
-        "line": 269,
+        "index": 6550,
+        "line": 293,
         "loc": {
           "end": {
             "column": 22,
-            "line": 269
+            "line": 293
           },
           "start": {
             "column": 15,
-            "line": 269
+            "line": 293
           }
         },
         "message": "\"quietly\" adds vague hidden significance (abstract-change). Name the concrete change or remove the adverb.",
         "range": [
-          6120,
-          6127
+          6550,
+          6557
         ],
         "ruleId": "quietly-filler",
         "severity": 1,
@@ -3697,33 +3973,33 @@
       {
         "column": 15,
         "data": {
-          "message": "\"quietly\" used 6 times (4.8 per 1,000 words), above the 2-per-1,000-word error threshold. Cut the filler uses; keep at most about one per 1,000 words.",
+          "message": "\"quietly\" used 6 times (4.5 per 1,000 words), above the 2-per-1,000-word error threshold. Cut the filler uses; keep at most about one per 1,000 words.",
           "padding": {
             "isAbsolute": false,
             "range": [
-              6120,
-              6127
+              6550,
+              6557
             ],
             "type": "TextlintRuleErrorPaddingLocation"
           },
           "severity": 2
         },
-        "index": 6120,
-        "line": 269,
+        "index": 6550,
+        "line": 293,
         "loc": {
           "end": {
             "column": 22,
-            "line": 269
+            "line": 293
           },
           "start": {
             "column": 15,
-            "line": 269
+            "line": 293
           }
         },
-        "message": "\"quietly\" used 6 times (4.8 per 1,000 words), above the 2-per-1,000-word error threshold. Cut the filler uses; keep at most about one per 1,000 words.",
+        "message": "\"quietly\" used 6 times (4.5 per 1,000 words), above the 2-per-1,000-word error threshold. Cut the filler uses; keep at most about one per 1,000 words.",
         "range": [
-          6120,
-          6127
+          6550,
+          6557
         ],
         "ruleId": "quietly-overuse",
         "severity": 2,
@@ -3731,310 +4007,11 @@
       },
       {
         "column": 1,
-        "index": 6139,
-        "line": 271,
-        "loc": {
-          "end": {
-            "column": 33,
-            "line": 271
-          },
-          "start": {
-            "column": 1,
-            "line": 271
-          }
-        },
-        "message": "Semantic thinness (something-shifted): Catch vague change declarations that say something shifted, changed, moved, or crossed a line without naming the concrete change. Matched template: {diffuseSubject} {progressiveAuxiliary} {weakMannerAdverb} {progressiveChange}.",
-        "range": [
-          6139,
-          6171
-        ],
-        "ruleId": "semantic-thinness",
-        "severity": 2,
-        "type": "lint"
-      },
-      {
-        "column": 1,
-        "index": 6173,
-        "line": 273,
-        "loc": {
-          "end": {
-            "column": 30,
-            "line": 273
-          },
-          "start": {
-            "column": 1,
-            "line": 273
-          }
-        },
-        "message": "Semantic thinness (something-shifted): Catch vague change declarations that say something shifted, changed, moved, or crossed a line without naming the concrete change. Matched template: {diffuseSubject} {progressiveAuxiliary} {weakMannerAdverb} {progressiveChange}.",
-        "range": [
-          6173,
-          6202
-        ],
-        "ruleId": "semantic-thinness",
-        "severity": 2,
-        "type": "lint"
-      },
-      {
-        "column": 1,
-        "index": 6204,
-        "line": 275,
-        "loc": {
-          "end": {
-            "column": 34,
-            "line": 275
-          },
-          "start": {
-            "column": 1,
-            "line": 275
-          }
-        },
-        "message": "Semantic thinness (something-shifted): Catch vague change declarations that say something shifted, changed, moved, or crossed a line without naming the concrete change. Matched template: {diffuseSubject} {progressiveAuxiliary} {weakMannerAdverb} {progressiveChange}.",
-        "range": [
-          6204,
-          6237
-        ],
-        "ruleId": "semantic-thinness",
-        "severity": 2,
-        "type": "lint"
-      },
-      {
-        "column": 1,
-        "index": 6239,
-        "line": 277,
-        "loc": {
-          "end": {
-            "column": 37,
-            "line": 277
-          },
-          "start": {
-            "column": 1,
-            "line": 277
-          }
-        },
-        "message": "Semantic thinness (something-shifted): Catch vague change declarations that say something shifted, changed, moved, or crossed a line without naming the concrete change. Matched template: {diffuseSubject} {progressiveAuxiliary} {weakMannerAdverb} {progressiveChange}.",
-        "range": [
-          6239,
-          6275
-        ],
-        "ruleId": "semantic-thinness",
-        "severity": 2,
-        "type": "lint"
-      },
-      {
-        "column": 1,
-        "index": 6277,
-        "line": 279,
-        "loc": {
-          "end": {
-            "column": 45,
-            "line": 279
-          },
-          "start": {
-            "column": 1,
-            "line": 279
-          }
-        },
-        "message": "Semantic thinness (something-shifted): Catch vague change declarations that say something shifted, changed, moved, or crossed a line without naming the concrete change. Matched template: {diffuseSubject} {progressiveAuxiliary} {weakMannerAdverb} {progressiveChange}.",
-        "range": [
-          6277,
-          6321
-        ],
-        "ruleId": "semantic-thinness",
-        "severity": 2,
-        "type": "lint"
-      },
-      {
-        "column": 1,
-        "index": 6323,
-        "line": 281,
-        "loc": {
-          "end": {
-            "column": 33,
-            "line": 281
-          },
-          "start": {
-            "column": 1,
-            "line": 281
-          }
-        },
-        "message": "Semantic thinness (something-shifted): Catch vague change declarations that say something shifted, changed, moved, or crossed a line without naming the concrete change. Matched template: {deicticSubject} {weakMannerAdverb} {emptyChangeObject}.",
-        "range": [
-          6323,
-          6355
-        ],
-        "ruleId": "semantic-thinness",
-        "severity": 2,
-        "type": "lint"
-      },
-      {
-        "column": 1,
-        "index": 6357,
-        "line": 283,
-        "loc": {
-          "end": {
-            "column": 33,
-            "line": 283
-          },
-          "start": {
-            "column": 1,
-            "line": 283
-          }
-        },
-        "message": "Semantic thinness (something-shifted): Catch vague change declarations that say something shifted, changed, moved, or crossed a line without naming the concrete change. Matched template: {deicticSubject} {weakMannerAdverb} {emptyChangeObject}.",
-        "range": [
-          6357,
-          6389
-        ],
-        "ruleId": "semantic-thinness",
-        "severity": 2,
-        "type": "lint"
-      },
-      {
-        "column": 1,
-        "index": 6391,
-        "line": 285,
-        "loc": {
-          "end": {
-            "column": 27,
-            "line": 285
-          },
-          "start": {
-            "column": 1,
-            "line": 285
-          }
-        },
-        "message": "Semantic thinness (something-shifted): Catch vague change declarations that say something shifted, changed, moved, or crossed a line without naming the concrete change. Matched template: {shiftDeterminer} {shiftModifier} shift {emptyShiftPredicate}.",
-        "range": [
-          6391,
-          6417
-        ],
-        "ruleId": "semantic-thinness",
-        "severity": 2,
-        "type": "lint"
-      },
-      {
-        "column": 1,
-        "index": 6419,
-        "line": 287,
-        "loc": {
-          "end": {
-            "column": 31,
-            "line": 287
-          },
-          "start": {
-            "column": 1,
-            "line": 287
-          }
-        },
-        "message": "Semantic thinness (something-shifted): Catch vague change declarations that say something shifted, changed, moved, or crossed a line without naming the concrete change. Matched template: {shiftDeterminer} {shiftModifier} shift {emptyShiftPredicate}.",
-        "range": [
-          6419,
-          6449
-        ],
-        "ruleId": "semantic-thinness",
-        "severity": 2,
-        "type": "lint"
-      },
-      {
-        "column": 1,
-        "index": 6451,
-        "line": 289,
-        "loc": {
-          "end": {
-            "column": 30,
-            "line": 289
-          },
-          "start": {
-            "column": 1,
-            "line": 289
-          }
-        },
-        "message": "Semantic thinness (something-shifted): Catch vague change declarations that say something shifted, changed, moved, or crossed a line without naming the concrete change. Matched template: {shiftDeterminer} {shiftModifier} shift {emptyShiftPredicate}.",
-        "range": [
-          6451,
-          6480
-        ],
-        "ruleId": "semantic-thinness",
-        "severity": 2,
-        "type": "lint"
-      },
-      {
-        "column": 1,
-        "index": 6482,
-        "line": 291,
-        "loc": {
-          "end": {
-            "column": 36,
-            "line": 291
-          },
-          "start": {
-            "column": 1,
-            "line": 291
-          }
-        },
-        "message": "Semantic thinness (something-shifted): Catch vague change declarations that say something shifted, changed, moved, or crossed a line without naming the concrete change. Matched template: {shiftDeterminer} {shiftModifier} shift {emptyShiftPredicate}.",
-        "range": [
-          6482,
-          6517
-        ],
-        "ruleId": "semantic-thinness",
-        "severity": 2,
-        "type": "lint"
-      },
-      {
-        "column": 1,
-        "index": 6519,
-        "line": 293,
-        "loc": {
-          "end": {
-            "column": 37,
-            "line": 293
-          },
-          "start": {
-            "column": 1,
-            "line": 293
-          }
-        },
-        "message": "Generic signposting found: the-important-shift-is. Replace the frame with the concrete claim.",
-        "range": [
-          6519,
-          6555
-        ],
-        "ruleId": "generic-signposting",
-        "severity": 2,
-        "type": "lint"
-      },
-      {
-        "column": 1,
-        "index": 6519,
-        "line": 293,
-        "loc": {
-          "end": {
-            "column": 37,
-            "line": 293
-          },
-          "start": {
-            "column": 1,
-            "line": 293
-          }
-        },
-        "message": "Semantic thinness (something-shifted): Catch vague change declarations that say something shifted, changed, moved, or crossed a line without naming the concrete change. Matched template: {shiftDeterminer} {shiftModifier} shift {emptyShiftPredicate}.",
-        "range": [
-          6519,
-          6555
-        ],
-        "ruleId": "semantic-thinness",
-        "severity": 2,
-        "type": "lint"
-      },
-      {
-        "column": 1,
-        "index": 6557,
+        "index": 6569,
         "line": 295,
         "loc": {
           "end": {
-            "column": 41,
+            "column": 33,
             "line": 295
           },
           "start": {
@@ -4042,10 +4019,10 @@
             "line": 295
           }
         },
-        "message": "Semantic thinness (something-shifted): Catch vague change declarations that say something shifted, changed, moved, or crossed a line without naming the concrete change. Matched template: {shiftDeterminer} {shiftModifier} shift {emptyShiftPredicate}.",
+        "message": "Semantic thinness (something-shifted): Catch vague change declarations that say something shifted, changed, moved, or crossed a line without naming the concrete change. Matched template: {diffuseSubject} {progressiveAuxiliary} {weakMannerAdverb} {progressiveChange}.",
         "range": [
-          6557,
-          6597
+          6569,
+          6601
         ],
         "ruleId": "semantic-thinness",
         "severity": 2,
@@ -4053,7 +4030,7 @@
       },
       {
         "column": 1,
-        "index": 6599,
+        "index": 6603,
         "line": 297,
         "loc": {
           "end": {
@@ -4065,10 +4042,10 @@
             "line": 297
           }
         },
-        "message": "Semantic thinness (something-shifted): Catch vague change declarations that say something shifted, changed, moved, or crossed a line without naming the concrete change. Matched template: {shiftDeterminer} {shiftModifier} shift {emptyShiftPredicate}.",
+        "message": "Semantic thinness (something-shifted): Catch vague change declarations that say something shifted, changed, moved, or crossed a line without naming the concrete change. Matched template: {diffuseSubject} {progressiveAuxiliary} {weakMannerAdverb} {progressiveChange}.",
         "range": [
-          6599,
-          6628
+          6603,
+          6632
         ],
         "ruleId": "semantic-thinness",
         "severity": 2,
@@ -4076,22 +4053,137 @@
       },
       {
         "column": 1,
-        "index": 6630,
+        "index": 6634,
         "line": 299,
         "loc": {
           "end": {
-            "column": 39,
+            "column": 34,
             "line": 299
           },
           "start": {
             "column": 1,
             "line": 299
+          }
+        },
+        "message": "Semantic thinness (something-shifted): Catch vague change declarations that say something shifted, changed, moved, or crossed a line without naming the concrete change. Matched template: {diffuseSubject} {progressiveAuxiliary} {weakMannerAdverb} {progressiveChange}.",
+        "range": [
+          6634,
+          6667
+        ],
+        "ruleId": "semantic-thinness",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 6669,
+        "line": 301,
+        "loc": {
+          "end": {
+            "column": 37,
+            "line": 301
+          },
+          "start": {
+            "column": 1,
+            "line": 301
+          }
+        },
+        "message": "Semantic thinness (something-shifted): Catch vague change declarations that say something shifted, changed, moved, or crossed a line without naming the concrete change. Matched template: {diffuseSubject} {progressiveAuxiliary} {weakMannerAdverb} {progressiveChange}.",
+        "range": [
+          6669,
+          6705
+        ],
+        "ruleId": "semantic-thinness",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 6707,
+        "line": 303,
+        "loc": {
+          "end": {
+            "column": 45,
+            "line": 303
+          },
+          "start": {
+            "column": 1,
+            "line": 303
+          }
+        },
+        "message": "Semantic thinness (something-shifted): Catch vague change declarations that say something shifted, changed, moved, or crossed a line without naming the concrete change. Matched template: {diffuseSubject} {progressiveAuxiliary} {weakMannerAdverb} {progressiveChange}.",
+        "range": [
+          6707,
+          6751
+        ],
+        "ruleId": "semantic-thinness",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 6753,
+        "line": 305,
+        "loc": {
+          "end": {
+            "column": 33,
+            "line": 305
+          },
+          "start": {
+            "column": 1,
+            "line": 305
+          }
+        },
+        "message": "Semantic thinness (something-shifted): Catch vague change declarations that say something shifted, changed, moved, or crossed a line without naming the concrete change. Matched template: {deicticSubject} {weakMannerAdverb} {emptyChangeObject}.",
+        "range": [
+          6753,
+          6785
+        ],
+        "ruleId": "semantic-thinness",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 6787,
+        "line": 307,
+        "loc": {
+          "end": {
+            "column": 33,
+            "line": 307
+          },
+          "start": {
+            "column": 1,
+            "line": 307
+          }
+        },
+        "message": "Semantic thinness (something-shifted): Catch vague change declarations that say something shifted, changed, moved, or crossed a line without naming the concrete change. Matched template: {deicticSubject} {weakMannerAdverb} {emptyChangeObject}.",
+        "range": [
+          6787,
+          6819
+        ],
+        "ruleId": "semantic-thinness",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 6821,
+        "line": 309,
+        "loc": {
+          "end": {
+            "column": 27,
+            "line": 309
+          },
+          "start": {
+            "column": 1,
+            "line": 309
           }
         },
         "message": "Semantic thinness (something-shifted): Catch vague change declarations that say something shifted, changed, moved, or crossed a line without naming the concrete change. Matched template: {shiftDeterminer} {shiftModifier} shift {emptyShiftPredicate}.",
         "range": [
-          6630,
-          6668
+          6821,
+          6847
         ],
         "ruleId": "semantic-thinness",
         "severity": 2,
@@ -4099,22 +4191,22 @@
       },
       {
         "column": 1,
-        "index": 6670,
-        "line": 301,
+        "index": 6849,
+        "line": 311,
         "loc": {
           "end": {
-            "column": 28,
-            "line": 301
+            "column": 31,
+            "line": 311
           },
           "start": {
             "column": 1,
-            "line": 301
+            "line": 311
           }
         },
-        "message": "Semantic thinness (something-shifted): Catch vague change declarations that say something shifted, changed, moved, or crossed a line without naming the concrete change. Matched template: {deicticSubject} {signalVerb} {shiftDeterminer} {shiftModifier} shift.",
+        "message": "Semantic thinness (something-shifted): Catch vague change declarations that say something shifted, changed, moved, or crossed a line without naming the concrete change. Matched template: {shiftDeterminer} {shiftModifier} shift {emptyShiftPredicate}.",
         "range": [
-          6670,
-          6697
+          6849,
+          6879
         ],
         "ruleId": "semantic-thinness",
         "severity": 2,
@@ -4122,22 +4214,206 @@
       },
       {
         "column": 1,
-        "index": 6699,
-        "line": 303,
+        "index": 6881,
+        "line": 313,
         "loc": {
           "end": {
             "column": 30,
-            "line": 303
+            "line": 313
           },
           "start": {
             "column": 1,
-            "line": 303
+            "line": 313
+          }
+        },
+        "message": "Semantic thinness (something-shifted): Catch vague change declarations that say something shifted, changed, moved, or crossed a line without naming the concrete change. Matched template: {shiftDeterminer} {shiftModifier} shift {emptyShiftPredicate}.",
+        "range": [
+          6881,
+          6910
+        ],
+        "ruleId": "semantic-thinness",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 6912,
+        "line": 315,
+        "loc": {
+          "end": {
+            "column": 36,
+            "line": 315
+          },
+          "start": {
+            "column": 1,
+            "line": 315
+          }
+        },
+        "message": "Semantic thinness (something-shifted): Catch vague change declarations that say something shifted, changed, moved, or crossed a line without naming the concrete change. Matched template: {shiftDeterminer} {shiftModifier} shift {emptyShiftPredicate}.",
+        "range": [
+          6912,
+          6947
+        ],
+        "ruleId": "semantic-thinness",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 6949,
+        "line": 317,
+        "loc": {
+          "end": {
+            "column": 37,
+            "line": 317
+          },
+          "start": {
+            "column": 1,
+            "line": 317
+          }
+        },
+        "message": "Generic signposting found: the-important-shift-is. Replace the frame with the concrete claim.",
+        "range": [
+          6949,
+          6985
+        ],
+        "ruleId": "generic-signposting",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 6949,
+        "line": 317,
+        "loc": {
+          "end": {
+            "column": 37,
+            "line": 317
+          },
+          "start": {
+            "column": 1,
+            "line": 317
+          }
+        },
+        "message": "Semantic thinness (something-shifted): Catch vague change declarations that say something shifted, changed, moved, or crossed a line without naming the concrete change. Matched template: {shiftDeterminer} {shiftModifier} shift {emptyShiftPredicate}.",
+        "range": [
+          6949,
+          6985
+        ],
+        "ruleId": "semantic-thinness",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 6987,
+        "line": 319,
+        "loc": {
+          "end": {
+            "column": 41,
+            "line": 319
+          },
+          "start": {
+            "column": 1,
+            "line": 319
+          }
+        },
+        "message": "Semantic thinness (something-shifted): Catch vague change declarations that say something shifted, changed, moved, or crossed a line without naming the concrete change. Matched template: {shiftDeterminer} {shiftModifier} shift {emptyShiftPredicate}.",
+        "range": [
+          6987,
+          7027
+        ],
+        "ruleId": "semantic-thinness",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 7029,
+        "line": 321,
+        "loc": {
+          "end": {
+            "column": 30,
+            "line": 321
+          },
+          "start": {
+            "column": 1,
+            "line": 321
+          }
+        },
+        "message": "Semantic thinness (something-shifted): Catch vague change declarations that say something shifted, changed, moved, or crossed a line without naming the concrete change. Matched template: {shiftDeterminer} {shiftModifier} shift {emptyShiftPredicate}.",
+        "range": [
+          7029,
+          7058
+        ],
+        "ruleId": "semantic-thinness",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 7060,
+        "line": 323,
+        "loc": {
+          "end": {
+            "column": 39,
+            "line": 323
+          },
+          "start": {
+            "column": 1,
+            "line": 323
+          }
+        },
+        "message": "Semantic thinness (something-shifted): Catch vague change declarations that say something shifted, changed, moved, or crossed a line without naming the concrete change. Matched template: {shiftDeterminer} {shiftModifier} shift {emptyShiftPredicate}.",
+        "range": [
+          7060,
+          7098
+        ],
+        "ruleId": "semantic-thinness",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 7100,
+        "line": 325,
+        "loc": {
+          "end": {
+            "column": 28,
+            "line": 325
+          },
+          "start": {
+            "column": 1,
+            "line": 325
           }
         },
         "message": "Semantic thinness (something-shifted): Catch vague change declarations that say something shifted, changed, moved, or crossed a line without naming the concrete change. Matched template: {deicticSubject} {signalVerb} {shiftDeterminer} {shiftModifier} shift.",
         "range": [
-          6699,
-          6728
+          7100,
+          7127
+        ],
+        "ruleId": "semantic-thinness",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 7129,
+        "line": 327,
+        "loc": {
+          "end": {
+            "column": 30,
+            "line": 327
+          },
+          "start": {
+            "column": 1,
+            "line": 327
+          }
+        },
+        "message": "Semantic thinness (something-shifted): Catch vague change declarations that say something shifted, changed, moved, or crossed a line without naming the concrete change. Matched template: {deicticSubject} {signalVerb} {shiftDeterminer} {shiftModifier} shift.",
+        "range": [
+          7129,
+          7158
         ],
         "ruleId": "semantic-thinness",
         "severity": 2,
@@ -4145,22 +4421,22 @@
       },
       {
         "column": 6,
-        "index": 6704,
-        "line": 303,
+        "index": 7134,
+        "line": 327,
         "loc": {
           "end": {
             "column": 29,
-            "line": 303
+            "line": 327
           },
           "start": {
             "column": 6,
-            "line": 303
+            "line": 327
           }
         },
         "message": "Cliche found: \"signals a seismic shift\". Replace it with specific wording.",
         "range": [
-          6704,
-          6727
+          7134,
+          7157
         ],
         "ruleId": "cliches",
         "severity": 2,
@@ -4168,22 +4444,22 @@
       },
       {
         "column": 1,
-        "index": 6730,
-        "line": 305,
+        "index": 7160,
+        "line": 329,
         "loc": {
           "end": {
             "column": 36,
-            "line": 305
+            "line": 329
           },
           "start": {
             "column": 1,
-            "line": 305
+            "line": 329
           }
         },
         "message": "Semantic thinness (something-shifted): Catch vague change declarations that say something shifted, changed, moved, or crossed a line without naming the concrete change. Matched template: {deicticSubject} {signalVerb} {shiftDeterminer} {shiftModifier} shift.",
         "range": [
-          6730,
-          6765
+          7160,
+          7195
         ],
         "ruleId": "semantic-thinness",
         "severity": 2,
@@ -4191,22 +4467,22 @@
       },
       {
         "column": 1,
-        "index": 6767,
-        "line": 307,
+        "index": 7197,
+        "line": 331,
         "loc": {
           "end": {
             "column": 31,
-            "line": 307
+            "line": 331
           },
           "start": {
             "column": 1,
-            "line": 307
+            "line": 331
           }
         },
         "message": "Semantic thinness (something-shifted): Catch vague change declarations that say something shifted, changed, moved, or crossed a line without naming the concrete change. Matched template: {deicticSubject} {signalVerb} {shiftDeterminer} {shiftModifier} shift.",
         "range": [
-          6767,
-          6797
+          7197,
+          7227
         ],
         "ruleId": "semantic-thinness",
         "severity": 2,
@@ -4214,22 +4490,22 @@
       },
       {
         "column": 1,
-        "index": 6799,
-        "line": 309,
+        "index": 7229,
+        "line": 333,
         "loc": {
           "end": {
             "column": 29,
-            "line": 309
+            "line": 333
           },
           "start": {
             "column": 1,
-            "line": 309
+            "line": 333
           }
         },
         "message": "Semantic thinness (something-shifted): Catch vague change declarations that say something shifted, changed, moved, or crossed a line without naming the concrete change. Matched template: {diffuseSubject} {weakMannerAdverb} {finiteChange}.",
         "range": [
-          6799,
-          6827
+          7229,
+          7257
         ],
         "ruleId": "semantic-thinness",
         "severity": 2,
@@ -4237,22 +4513,22 @@
       },
       {
         "column": 1,
-        "index": 6829,
-        "line": 311,
+        "index": 7259,
+        "line": 335,
         "loc": {
           "end": {
             "column": 28,
-            "line": 311
+            "line": 335
           },
           "start": {
             "column": 1,
-            "line": 311
+            "line": 335
           }
         },
         "message": "Semantic thinness (something-shifted): Catch vague change declarations that say something shifted, changed, moved, or crossed a line without naming the concrete change. Matched template: {diffuseSubject} {weakMannerAdverb} {finiteChange}.",
         "range": [
-          6829,
-          6856
+          7259,
+          7286
         ],
         "ruleId": "semantic-thinness",
         "severity": 2,
@@ -4272,22 +4548,22 @@
           },
           "severity": 1
         },
-        "index": 6840,
-        "line": 311,
+        "index": 7270,
+        "line": 335,
         "loc": {
           "end": {
             "column": 19,
-            "line": 311
+            "line": 335
           },
           "start": {
             "column": 12,
-            "line": 311
+            "line": 335
           }
         },
         "message": "\"quietly\" adds vague hidden significance (abstract-change). Name the concrete change or remove the adverb.",
         "range": [
-          6840,
-          6847
+          7270,
+          7277
         ],
         "ruleId": "quietly-filler",
         "severity": 1,
@@ -4295,22 +4571,22 @@
       },
       {
         "column": 1,
-        "index": 6858,
-        "line": 313,
+        "index": 7288,
+        "line": 337,
         "loc": {
           "end": {
             "column": 35,
-            "line": 313
+            "line": 337
           },
           "start": {
             "column": 1,
-            "line": 313
+            "line": 337
           }
         },
         "message": "Semantic thinness (something-shifted): Catch vague change declarations that say something shifted, changed, moved, or crossed a line without naming the concrete change. Matched template: {diffuseSubject} {progressiveAuxiliary} {weakMannerAdverb} {progressiveChange}.",
         "range": [
-          6858,
-          6892
+          7288,
+          7322
         ],
         "ruleId": "semantic-thinness",
         "severity": 2,
@@ -4318,22 +4594,22 @@
       },
       {
         "column": 1,
-        "index": 6894,
-        "line": 315,
+        "index": 7324,
+        "line": 339,
         "loc": {
           "end": {
             "column": 34,
-            "line": 315
+            "line": 339
           },
           "start": {
             "column": 1,
-            "line": 315
+            "line": 339
           }
         },
         "message": "Semantic thinness (something-shifted): Catch vague change declarations that say something shifted, changed, moved, or crossed a line without naming the concrete change. Matched template: {diffuseSubject} {perfectAuxiliary} {weakMannerAdverb} {pastChange}.",
         "range": [
-          6894,
-          6927
+          7324,
+          7357
         ],
         "ruleId": "semantic-thinness",
         "severity": 2,
@@ -4353,22 +4629,22 @@
           },
           "severity": 1
         },
-        "index": 6911,
-        "line": 315,
+        "index": 7341,
+        "line": 339,
         "loc": {
           "end": {
             "column": 25,
-            "line": 315
+            "line": 339
           },
           "start": {
             "column": 18,
-            "line": 315
+            "line": 339
           }
         },
         "message": "\"quietly\" adds vague hidden significance (abstract-change). Name the concrete change or remove the adverb.",
         "range": [
-          6911,
-          6918
+          7341,
+          7348
         ],
         "ruleId": "quietly-filler",
         "severity": 1,
@@ -4376,22 +4652,22 @@
       },
       {
         "column": 1,
-        "index": 6929,
-        "line": 317,
+        "index": 7359,
+        "line": 341,
         "loc": {
           "end": {
             "column": 31,
-            "line": 317
+            "line": 341
           },
           "start": {
             "column": 1,
-            "line": 317
+            "line": 341
           }
         },
         "message": "Semantic thinness (something-shifted): Catch vague change declarations that say something shifted, changed, moved, or crossed a line without naming the concrete change. Matched template: {diffuseSubject} {perfectAuxiliary} {weakMannerAdverb} {pastChange}.",
         "range": [
-          6929,
-          6959
+          7359,
+          7389
         ],
         "ruleId": "semantic-thinness",
         "severity": 2,
@@ -4411,22 +4687,22 @@
           },
           "severity": 1
         },
-        "index": 6943,
-        "line": 317,
+        "index": 7373,
+        "line": 341,
         "loc": {
           "end": {
             "column": 22,
-            "line": 317
+            "line": 341
           },
           "start": {
             "column": 15,
-            "line": 317
+            "line": 341
           }
         },
         "message": "\"quietly\" adds vague hidden significance (abstract-change). Name the concrete change or remove the adverb.",
         "range": [
-          6943,
-          6950
+          7373,
+          7380
         ],
         "ruleId": "quietly-filler",
         "severity": 1,
@@ -4434,22 +4710,22 @@
       },
       {
         "column": 1,
-        "index": 6961,
-        "line": 319,
+        "index": 7391,
+        "line": 343,
         "loc": {
           "end": {
             "column": 28,
-            "line": 319
+            "line": 343
           },
           "start": {
             "column": 1,
-            "line": 319
+            "line": 343
           }
         },
         "message": "Semantic thinness (something-shifted): Catch vague change declarations that say something shifted, changed, moved, or crossed a line without naming the concrete change. Matched template: {diffuseSubject} {finiteChange} {weakMannerAdverb}.",
         "range": [
-          6961,
-          6988
+          7391,
+          7418
         ],
         "ruleId": "semantic-thinness",
         "severity": 2,
@@ -4469,22 +4745,22 @@
           },
           "severity": 1
         },
-        "index": 6980,
-        "line": 319,
+        "index": 7410,
+        "line": 343,
         "loc": {
           "end": {
             "column": 27,
-            "line": 319
+            "line": 343
           },
           "start": {
             "column": 20,
-            "line": 319
+            "line": 343
           }
         },
         "message": "\"quietly\" adds vague hidden significance (abstract-change). Name the concrete change or remove the adverb.",
         "range": [
-          6980,
-          6987
+          7410,
+          7417
         ],
         "ruleId": "quietly-filler",
         "severity": 1,
@@ -4492,22 +4768,22 @@
       },
       {
         "column": 1,
-        "index": 6990,
-        "line": 321,
+        "index": 7420,
+        "line": 345,
         "loc": {
           "end": {
             "column": 20,
-            "line": 321
+            "line": 345
           },
           "start": {
             "column": 1,
-            "line": 321
+            "line": 345
           }
         },
         "message": "Semantic thinness (deictic-summary): Catch deictic summary pronouncements that point at a supposed lesson, truth, promise, or part without naming the concrete claim. Matched template: {deicticCopula} the {summaryNoun}.",
         "range": [
-          6990,
-          7009
+          7420,
+          7439
         ],
         "ruleId": "semantic-thinness",
         "severity": 2,
@@ -4515,22 +4791,22 @@
       },
       {
         "column": 1,
-        "index": 7011,
-        "line": 323,
+        "index": 7441,
+        "line": 347,
         "loc": {
           "end": {
             "column": 26,
-            "line": 323
+            "line": 347
           },
           "start": {
             "column": 1,
-            "line": 323
+            "line": 347
           }
         },
         "message": "Semantic thinness (deictic-summary): Catch deictic summary pronouncements that point at a supposed lesson, truth, promise, or part without naming the concrete claim. Matched template: {deicticCopula} the {evaluativeAdjective} {summaryNoun}.",
         "range": [
-          7011,
-          7036
+          7441,
+          7466
         ],
         "ruleId": "semantic-thinness",
         "severity": 2,
@@ -4538,22 +4814,22 @@
       },
       {
         "column": 1,
-        "index": 7038,
-        "line": 325,
+        "index": 7468,
+        "line": 349,
         "loc": {
           "end": {
             "column": 24,
-            "line": 325
+            "line": 349
           },
           "start": {
             "column": 1,
-            "line": 325
+            "line": 349
           }
         },
         "message": "Semantic thinness (deictic-summary): Catch deictic summary pronouncements that point at a supposed lesson, truth, promise, or part without naming the concrete claim. Matched template: {deicticCopula} the {evaluativeAdjective} {summaryNoun}.",
         "range": [
-          7038,
-          7061
+          7468,
+          7491
         ],
         "ruleId": "semantic-thinness",
         "severity": 2,
@@ -4561,22 +4837,22 @@
       },
       {
         "column": 1,
-        "index": 7063,
-        "line": 327,
+        "index": 7493,
+        "line": 351,
         "loc": {
           "end": {
             "column": 60,
-            "line": 327
+            "line": 351
           },
           "start": {
             "column": 1,
-            "line": 327
+            "line": 351
           }
         },
         "message": "Semantic thinness (abstract-metaphor-claim): Catch slogan-like abstract metaphors where an abstract subject performs a physical or spatial action with no concrete referent. Matched template: {audiencePreposition} the {automatedAudience} {audienceActivity}, the {identityArtifact} {linkingVerb} the {artifactRole}.",
         "range": [
-          7063,
-          7122
+          7493,
+          7552
         ],
         "ruleId": "semantic-thinness",
         "severity": 2,
@@ -4584,22 +4860,22 @@
       },
       {
         "column": 1,
-        "index": 7124,
-        "line": 329,
+        "index": 7554,
+        "line": 353,
         "loc": {
           "end": {
             "column": 46,
-            "line": 329
+            "line": 353
           },
           "start": {
             "column": 1,
-            "line": 329
+            "line": 353
           }
         },
         "message": "Semantic thinness (abstract-metaphor-claim): Catch slogan-like abstract metaphors where an abstract subject performs a physical or spatial action with no concrete referent. Matched template: {audiencePreposition} the {automatedAudience}, the {identityArtifact} {linkingVerb} the {artifactRole}.",
         "range": [
-          7124,
-          7169
+          7554,
+          7599
         ],
         "ruleId": "semantic-thinness",
         "severity": 2,
@@ -4607,22 +4883,22 @@
       },
       {
         "column": 1,
-        "index": 7171,
-        "line": 331,
+        "index": 7601,
+        "line": 355,
         "loc": {
           "end": {
             "column": 53,
-            "line": 331
+            "line": 355
           },
           "start": {
             "column": 1,
-            "line": 331
+            "line": 355
           }
         },
         "message": "Semantic thinness (abstract-metaphor-claim): Catch slogan-like abstract metaphors where an abstract subject performs a physical or spatial action with no concrete referent. Matched template: {audiencePreposition} the {automatedAudience}, the {identityArtifact} {linkingVerb} the {artifactRole}.",
         "range": [
-          7171,
-          7223
+          7601,
+          7653
         ],
         "ruleId": "semantic-thinness",
         "severity": 2,
@@ -4630,22 +4906,22 @@
       },
       {
         "column": 1,
-        "index": 7225,
-        "line": 333,
+        "index": 7655,
+        "line": 357,
         "loc": {
           "end": {
             "column": 44,
-            "line": 333
+            "line": 357
           },
           "start": {
             "column": 1,
-            "line": 333
+            "line": 357
           }
         },
         "message": "Semantic thinness (abstract-metaphor-claim): Catch slogan-like abstract metaphors where an abstract subject performs a physical or spatial action with no concrete referent. Matched template: {audiencePreposition} the {automatedAudience}, {identityArtifact} {linkingVerb} the {artifactRole}.",
         "range": [
-          7225,
-          7268
+          7655,
+          7698
         ],
         "ruleId": "semantic-thinness",
         "severity": 2,
@@ -4653,22 +4929,22 @@
       },
       {
         "column": 1,
-        "index": 7270,
-        "line": 335,
+        "index": 7700,
+        "line": 359,
         "loc": {
           "end": {
             "column": 28,
-            "line": 335
+            "line": 359
           },
           "start": {
             "column": 1,
-            "line": 335
+            "line": 359
           }
         },
         "message": "Demonstrative emphasis found: \"The prompt is the strategy.\". Reduce repeated short emphasis lines.",
         "range": [
-          7270,
-          7297
+          7700,
+          7727
         ],
         "ruleId": "demonstrative-emphasis",
         "severity": 2,
@@ -4676,22 +4952,22 @@
       },
       {
         "column": 1,
-        "index": 7270,
-        "line": 335,
+        "index": 7700,
+        "line": 359,
         "loc": {
           "end": {
             "column": 28,
-            "line": 335
+            "line": 359
           },
           "start": {
             "column": 1,
-            "line": 335
+            "line": 359
           }
         },
         "message": "Semantic thinness (abstract-metaphor-claim): Catch slogan-like abstract metaphors where an abstract subject performs a physical or spatial action with no concrete referent. Matched template: the {identityArtifact} {linkingVerb} the {artifactRole}.",
         "range": [
-          7270,
-          7297
+          7700,
+          7727
         ],
         "ruleId": "semantic-thinness",
         "severity": 2,
@@ -4699,22 +4975,22 @@
       },
       {
         "column": 1,
-        "index": 7299,
-        "line": 337,
+        "index": 7729,
+        "line": 361,
         "loc": {
           "end": {
             "column": 31,
-            "line": 337
+            "line": 361
           },
           "start": {
             "column": 1,
-            "line": 337
+            "line": 361
           }
         },
         "message": "Demonstrative emphasis found: \"The dashboard is the decision.\". Reduce repeated short emphasis lines.",
         "range": [
-          7299,
-          7329
+          7729,
+          7759
         ],
         "ruleId": "demonstrative-emphasis",
         "severity": 2,
@@ -4722,22 +4998,22 @@
       },
       {
         "column": 1,
-        "index": 7299,
-        "line": 337,
+        "index": 7729,
+        "line": 361,
         "loc": {
           "end": {
             "column": 31,
-            "line": 337
+            "line": 361
           },
           "start": {
             "column": 1,
-            "line": 337
+            "line": 361
           }
         },
         "message": "Semantic thinness (abstract-metaphor-claim): Catch slogan-like abstract metaphors where an abstract subject performs a physical or spatial action with no concrete referent. Matched template: the {identityArtifact} {linkingVerb} the {artifactRole}.",
         "range": [
-          7299,
-          7329
+          7729,
+          7759
         ],
         "ruleId": "semantic-thinness",
         "severity": 2,
@@ -4745,22 +5021,22 @@
       },
       {
         "column": 1,
-        "index": 7331,
-        "line": 339,
+        "index": 7761,
+        "line": 363,
         "loc": {
           "end": {
             "column": 30,
-            "line": 339
+            "line": 363
           },
           "start": {
             "column": 1,
-            "line": 339
+            "line": 363
           }
         },
         "message": "Semantic thinness (abstract-metaphor-claim): Catch slogan-like abstract metaphors where an abstract subject performs a physical or spatial action with no concrete referent. Matched template: the {identityArtifact} {linkingVerb} the {artifactRole}.",
         "range": [
-          7331,
-          7360
+          7761,
+          7790
         ],
         "ruleId": "semantic-thinness",
         "severity": 2,
@@ -4768,22 +5044,22 @@
       },
       {
         "column": 1,
-        "index": 7362,
-        "line": 341,
+        "index": 7792,
+        "line": 365,
         "loc": {
           "end": {
             "column": 33,
-            "line": 341
+            "line": 365
           },
           "start": {
             "column": 1,
-            "line": 341
+            "line": 365
           }
         },
         "message": "Demonstrative emphasis found: \"The spreadsheet is the business.\". Reduce repeated short emphasis lines.",
         "range": [
-          7362,
-          7394
+          7792,
+          7824
         ],
         "ruleId": "demonstrative-emphasis",
         "severity": 2,
@@ -4791,22 +5067,22 @@
       },
       {
         "column": 1,
-        "index": 7362,
-        "line": 341,
+        "index": 7792,
+        "line": 365,
         "loc": {
           "end": {
             "column": 33,
-            "line": 341
+            "line": 365
           },
           "start": {
             "column": 1,
-            "line": 341
+            "line": 365
           }
         },
         "message": "Semantic thinness (abstract-metaphor-claim): Catch slogan-like abstract metaphors where an abstract subject performs a physical or spatial action with no concrete referent. Matched template: the {identityArtifact} {linkingVerb} the {artifactRole}.",
         "range": [
-          7362,
-          7394
+          7792,
+          7824
         ],
         "ruleId": "semantic-thinness",
         "severity": 2,
@@ -4814,22 +5090,22 @@
       },
       {
         "column": 1,
-        "index": 7396,
-        "line": 343,
+        "index": 7826,
+        "line": 367,
         "loc": {
           "end": {
             "column": 25,
-            "line": 343
+            "line": 367
           },
           "start": {
             "column": 1,
-            "line": 343
+            "line": 367
           }
         },
         "message": "Demonstrative emphasis found: \"The index is the market.\". Reduce repeated short emphasis lines.",
         "range": [
-          7396,
-          7420
+          7826,
+          7850
         ],
         "ruleId": "demonstrative-emphasis",
         "severity": 2,
@@ -4837,22 +5113,22 @@
       },
       {
         "column": 1,
-        "index": 7396,
-        "line": 343,
+        "index": 7826,
+        "line": 367,
         "loc": {
           "end": {
             "column": 25,
-            "line": 343
+            "line": 367
           },
           "start": {
             "column": 1,
-            "line": 343
+            "line": 367
           }
         },
         "message": "Semantic thinness (abstract-metaphor-claim): Catch slogan-like abstract metaphors where an abstract subject performs a physical or spatial action with no concrete referent. Matched template: the {identityArtifact} {linkingVerb} the {artifactRole}.",
         "range": [
-          7396,
-          7420
+          7826,
+          7850
         ],
         "ruleId": "semantic-thinness",
         "severity": 2,
@@ -4860,22 +5136,22 @@
       },
       {
         "column": 1,
-        "index": 7422,
-        "line": 345,
+        "index": 7852,
+        "line": 369,
         "loc": {
           "end": {
             "column": 26,
-            "line": 345
+            "line": 369
           },
           "start": {
             "column": 1,
-            "line": 345
+            "line": 369
           }
         },
         "message": "Demonstrative emphasis found: \"The pipeline is the work.\". Reduce repeated short emphasis lines.",
         "range": [
-          7422,
-          7447
+          7852,
+          7877
         ],
         "ruleId": "demonstrative-emphasis",
         "severity": 2,
@@ -4883,22 +5159,22 @@
       },
       {
         "column": 1,
-        "index": 7422,
-        "line": 345,
+        "index": 7852,
+        "line": 369,
         "loc": {
           "end": {
             "column": 26,
-            "line": 345
+            "line": 369
           },
           "start": {
             "column": 1,
-            "line": 345
+            "line": 369
           }
         },
         "message": "Semantic thinness (abstract-metaphor-claim): Catch slogan-like abstract metaphors where an abstract subject performs a physical or spatial action with no concrete referent. Matched template: the {identityArtifact} {linkingVerb} the {artifactRole}.",
         "range": [
-          7422,
-          7447
+          7852,
+          7877
         ],
         "ruleId": "semantic-thinness",
         "severity": 2,
@@ -4906,22 +5182,22 @@
       },
       {
         "column": 1,
-        "index": 7449,
-        "line": 347,
+        "index": 7879,
+        "line": 371,
         "loc": {
           "end": {
             "column": 33,
-            "line": 347
+            "line": 371
           },
           "start": {
             "column": 1,
-            "line": 347
+            "line": 371
           }
         },
         "message": "Demonstrative emphasis found: \"The interface is the experience.\". Reduce repeated short emphasis lines.",
         "range": [
-          7449,
-          7481
+          7879,
+          7911
         ],
         "ruleId": "demonstrative-emphasis",
         "severity": 2,
@@ -4929,22 +5205,22 @@
       },
       {
         "column": 1,
-        "index": 7449,
-        "line": 347,
+        "index": 7879,
+        "line": 371,
         "loc": {
           "end": {
             "column": 33,
-            "line": 347
+            "line": 371
           },
           "start": {
             "column": 1,
-            "line": 347
+            "line": 371
           }
         },
         "message": "Semantic thinness (abstract-metaphor-claim): Catch slogan-like abstract metaphors where an abstract subject performs a physical or spatial action with no concrete referent. Matched template: the {identityArtifact} {linkingVerb} the {artifactRole}.",
         "range": [
-          7449,
-          7481
+          7879,
+          7911
         ],
         "ruleId": "semantic-thinness",
         "severity": 2,
@@ -4952,22 +5228,22 @@
       },
       {
         "column": 1,
-        "index": 7483,
-        "line": 349,
+        "index": 7913,
+        "line": 373,
         "loc": {
           "end": {
             "column": 36,
-            "line": 349
+            "line": 373
           },
           "start": {
             "column": 1,
-            "line": 349
+            "line": 373
           }
         },
         "message": "Semantic thinness (abstract-metaphor-claim): Catch slogan-like abstract metaphors where an abstract subject performs a physical or spatial action with no concrete referent. Matched template: the {identityArtifact} {linkingVerb} the {artifactRole}.",
         "range": [
-          7483,
-          7518
+          7913,
+          7948
         ],
         "ruleId": "semantic-thinness",
         "severity": 2,
@@ -4975,22 +5251,22 @@
       },
       {
         "column": 1,
-        "index": 7520,
-        "line": 351,
+        "index": 7950,
+        "line": 375,
         "loc": {
           "end": {
             "column": 32,
-            "line": 351
+            "line": 375
           },
           "start": {
             "column": 1,
-            "line": 351
+            "line": 375
           }
         },
         "message": "Demonstrative emphasis found: \"So the feed is the product now.\". Reduce repeated short emphasis lines.",
         "range": [
-          7520,
-          7551
+          7950,
+          7981
         ],
         "ruleId": "demonstrative-emphasis",
         "severity": 2,
@@ -4998,22 +5274,22 @@
       },
       {
         "column": 1,
-        "index": 7520,
-        "line": 351,
+        "index": 7950,
+        "line": 375,
         "loc": {
           "end": {
             "column": 32,
-            "line": 351
+            "line": 375
           },
           "start": {
             "column": 1,
-            "line": 351
+            "line": 375
           }
         },
         "message": "Semantic thinness (abstract-metaphor-claim): Catch slogan-like abstract metaphors where an abstract subject performs a physical or spatial action with no concrete referent. Matched template: the {identityArtifact} {linkingVerb} the {artifactRole} now.",
         "range": [
-          7520,
-          7551
+          7950,
+          7981
         ],
         "ruleId": "semantic-thinness",
         "severity": 2,
@@ -5021,22 +5297,22 @@
       },
       {
         "column": 1,
-        "index": 7553,
-        "line": 353,
+        "index": 7983,
+        "line": 377,
         "loc": {
           "end": {
             "column": 18,
-            "line": 353
+            "line": 377
           },
           "start": {
             "column": 1,
-            "line": 353
+            "line": 377
           }
         },
         "message": "Semantic thinness (deictic-summary): Catch deictic summary pronouncements that point at a supposed lesson, truth, promise, or part without naming the concrete claim. Matched template: {deicticCopula} the {summaryNoun}.",
         "range": [
-          7553,
-          7570
+          7983,
+          8000
         ],
         "ruleId": "semantic-thinness",
         "severity": 2,
@@ -5061,7 +5337,7 @@
             "line": 1
           }
         },
-        "message": "Coleman-Liau is 13.08. Keep it at 12 or lower.",
+        "message": "Coleman-Liau is 13.26. Keep it at 12 or lower.",
         "range": [
           0,
           1
@@ -5084,7 +5360,7 @@
             "line": 1
           }
         },
-        "message": "Flesch Reading Ease is -1694.29. Keep it at 61 or higher.",
+        "message": "Flesch Reading Ease is -1822.18. Keep it at 61 or higher.",
         "range": [
           0,
           1
@@ -5107,7 +5383,7 @@
             "line": 1
           }
         },
-        "message": "Gunning Fog is 701.67. Keep it at 12 or lower.",
+        "message": "Gunning Fog is 752.05. Keep it at 12 or lower.",
         "range": [
           0,
           1
@@ -5211,7 +5487,7 @@
       {
         "column": 11,
         "data": {
-          "message": "\"quietly\" used 5 times (2.9 per 1,000 words), above the 2-per-1,000-word error threshold. Cut the filler uses; keep at most about one per 1,000 words.",
+          "message": "\"quietly\" used 5 times (2.7 per 1,000 words), above the 2-per-1,000-word error threshold. Cut the filler uses; keep at most about one per 1,000 words.",
           "padding": {
             "isAbsolute": false,
             "range": [
@@ -5234,7 +5510,7 @@
             "line": 299
           }
         },
-        "message": "\"quietly\" used 5 times (2.9 per 1,000 words), above the 2-per-1,000-word error threshold. Cut the filler uses; keep at most about one per 1,000 words.",
+        "message": "\"quietly\" used 5 times (2.7 per 1,000 words), above the 2-per-1,000-word error threshold. Cut the filler uses; keep at most about one per 1,000 words.",
         "range": [
           9496,
           9503
@@ -5245,22 +5521,22 @@
       },
       {
         "column": 1,
-        "index": 10410,
-        "line": 331,
+        "index": 11214,
+        "line": 355,
         "loc": {
           "end": {
             "column": 47,
-            "line": 331
+            "line": 355
           },
           "start": {
             "column": 1,
-            "line": 331
+            "line": 355
           }
         },
         "message": "Boilerplate conclusion found: that-is-the-point. Replace the closer with a specific ending.",
         "range": [
-          10410,
-          10456
+          11214,
+          11260
         ],
         "ruleId": "boilerplate-conclusion",
         "severity": 2,

--- a/behavior/golden/textlint-rules-cases-syntactic-patterns/approved.meta.json
+++ b/behavior/golden/textlint-rules-cases-syntactic-patterns/approved.meta.json
@@ -1,27 +1,27 @@
 {
   "suite": "textlint-rules-cases-syntactic-patterns",
   "kind": "approved",
-  "run_id": "2026-07-24T22-11-36.301114Z-04547efb",
-  "run_commit": "0b4d4c6",
+  "run_id": "2026-07-28T11-33-07.587713Z-04547efb",
+  "run_commit": "4d6c658",
   "working_tree": "dirty",
-  "recorded_at": "2026-07-24T22:11:36.301114Z",
-  "fixture_hash": "sha256:a83b3c8fb281042574496aba3f27e12bfab9d440663f9fbb3b212edd5c00375d",
+  "recorded_at": "2026-07-28T11:33:07.587713Z",
+  "fixture_hash": "sha256:039ac17ac0a07694850e38140dce4e0587a53f451c1fbb246d981d943244494d",
   "manifest_hash": "sha256:04547efbb13157ee3d8ef18dda767231fd63d3f9cc27c15317cf28c5f0583e7b",
   "tool_version": "0.1.8",
   "output_schema_version": "1",
   "fixtures": [
     {
       "path": "behavior/fixtures/textlint-rules/cases/syntactic-patterns/hits.md",
-      "sha256": "sha256:d23bc8684eb55d2e821aa0605719a033df3b913e3ac8a0eda1ef94d44889da34"
+      "sha256": "sha256:130119e8aef40381c594d2b8e0aff9ad9ddb1f20c77812e15c67303cf206312c"
     },
     {
       "path": "behavior/fixtures/textlint-rules/cases/syntactic-patterns/no-hits.md",
-      "sha256": "sha256:f050f76da441343720ebe88642c6e74c1a826d8630c72e20b19deb78d0ec63e9"
+      "sha256": "sha256:52f8349249a3bddc1ad7178cffebfcc6344196898d03b9df6c14039a0110f0f8"
     },
     {
       "path": "behavior/fixtures/textlint-rules/cases/syntactic-patterns/significance-density.md",
       "sha256": "sha256:a5489177104e3714ea3558c1d90bdd91573bf719c83112225ae9e9b0e288c6da"
     }
   ],
-  "comment": "Reviewed contextual quietly warnings, list traversal, and unchanged prior findings"
+  "comment": "Add vague superlative-source hits and specific-source controls."
 }

--- a/behavior/golden/textlint-rules-cases-syntactic-patterns/approved.normalized.json
+++ b/behavior/golden/textlint-rules-cases-syntactic-patterns/approved.normalized.json
@@ -16,7 +16,7 @@
             "line": 1
           }
         },
-        "message": "Flesch Reading Ease is 50.8. Keep it at 61 or higher.",
+        "message": "Flesch Reading Ease is 50.2. Keep it at 61 or higher.",
         "range": [
           0,
           1
@@ -39,7 +39,7 @@
             "line": 1
           }
         },
-        "message": "Gunning Fog is 13.85. Keep it at 12 or lower.",
+        "message": "Gunning Fog is 14.08. Keep it at 12 or lower.",
         "range": [
           0,
           1
@@ -17619,6 +17619,420 @@
         "ruleId": "generic-signposting",
         "severity": 2,
         "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 61665,
+        "line": 1499,
+        "loc": {
+          "end": {
+            "column": 77,
+            "line": 1499
+          },
+          "start": {
+            "column": 1,
+            "line": 1499
+          }
+        },
+        "message": "Universalizing claim found: some of the biggest shifts in leadership come from experiences outside work. Replace the broad claim with a bounded claim.",
+        "range": [
+          61665,
+          61741
+        ],
+        "ruleId": "universalizing-claims",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 61743,
+        "line": 1501,
+        "loc": {
+          "end": {
+            "column": 60,
+            "line": 1501
+          },
+          "start": {
+            "column": 1,
+            "line": 1501
+          }
+        },
+        "message": "Universalizing claim found: some of the greatest lessons in business come from failure. Replace the broad claim with a bounded claim.",
+        "range": [
+          61743,
+          61802
+        ],
+        "ruleId": "universalizing-claims",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 61804,
+        "line": 1503,
+        "loc": {
+          "end": {
+            "column": 66,
+            "line": 1503
+          },
+          "start": {
+            "column": 1,
+            "line": 1503
+          }
+        },
+        "message": "Universalizing claim found: many of the deepest insights in leadership emerge from adversity. Replace the broad claim with a bounded claim.",
+        "range": [
+          61804,
+          61869
+        ],
+        "ruleId": "universalizing-claims",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 61871,
+        "line": 1505,
+        "loc": {
+          "end": {
+            "column": 62,
+            "line": 1505
+          },
+          "start": {
+            "column": 1,
+            "line": 1505
+          }
+        },
+        "message": "Universalizing claim found: some of the best ideas in design come from unexpected places. Replace the broad claim with a bounded claim.",
+        "range": [
+          61871,
+          61932
+        ],
+        "ruleId": "universalizing-claims",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 61934,
+        "line": 1507,
+        "loc": {
+          "end": {
+            "column": 63,
+            "line": 1507
+          },
+          "start": {
+            "column": 1,
+            "line": 1507
+          }
+        },
+        "message": "Universalizing claim found: some of the strongest skills in management grow from setbacks. Replace the broad claim with a bounded claim.",
+        "range": [
+          61934,
+          61996
+        ],
+        "ruleId": "universalizing-claims",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 61998,
+        "line": 1509,
+        "loc": {
+          "end": {
+            "column": 64,
+            "line": 1509
+          },
+          "start": {
+            "column": 1,
+            "line": 1509
+          }
+        },
+        "message": "Universalizing claim found: many of the most valuable lessons in life come from discomfort. Replace the broad claim with a bounded claim.",
+        "range": [
+          61998,
+          62061
+        ],
+        "ruleId": "universalizing-claims",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 62063,
+        "line": 1511,
+        "loc": {
+          "end": {
+            "column": 67,
+            "line": 1511
+          },
+          "start": {
+            "column": 1,
+            "line": 1511
+          }
+        },
+        "message": "Universalizing claim found: some of the most meaningful changes in careers start with failure. Replace the broad claim with a bounded claim.",
+        "range": [
+          62063,
+          62129
+        ],
+        "ruleId": "universalizing-claims",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 62131,
+        "line": 1513,
+        "loc": {
+          "end": {
+            "column": 72,
+            "line": 1513
+          },
+          "start": {
+            "column": 1,
+            "line": 1513
+          }
+        },
+        "message": "Universalizing claim found: some of the biggest breakthroughs in technology emerge from challenges. Replace the broad claim with a bounded claim.",
+        "range": [
+          62131,
+          62202
+        ],
+        "ruleId": "universalizing-claims",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 62204,
+        "line": 1515,
+        "loc": {
+          "end": {
+            "column": 72,
+            "line": 1515
+          },
+          "start": {
+            "column": 1,
+            "line": 1515
+          }
+        },
+        "message": "Universalizing claim found: many of the most useful insights in writing come from ordinary moments. Replace the broad claim with a bounded claim.",
+        "range": [
+          62204,
+          62275
+        ],
+        "ruleId": "universalizing-claims",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 62277,
+        "line": 1517,
+        "loc": {
+          "end": {
+            "column": 68,
+            "line": 1517
+          },
+          "start": {
+            "column": 1,
+            "line": 1517
+          }
+        },
+        "message": "Universalizing claim found: some of the greatest improvements in strategy begin with adversity. Replace the broad claim with a bounded claim.",
+        "range": [
+          62277,
+          62344
+        ],
+        "ruleId": "universalizing-claims",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 62346,
+        "line": 1519,
+        "loc": {
+          "end": {
+            "column": 61,
+            "line": 1519
+          },
+          "start": {
+            "column": 1,
+            "line": 1519
+          }
+        },
+        "message": "Universalizing claim found: some of the best decisions in business came from experience. Replace the broad claim with a bounded claim.",
+        "range": [
+          62346,
+          62406
+        ],
+        "ruleId": "universalizing-claims",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 62408,
+        "line": 1521,
+        "loc": {
+          "end": {
+            "column": 79,
+            "line": 1521
+          },
+          "start": {
+            "column": 1,
+            "line": 1521
+          }
+        },
+        "message": "Universalizing claim found: many of the strongest skills in leadership grew from experiences outside work. Replace the broad claim with a bounded claim.",
+        "range": [
+          62408,
+          62486
+        ],
+        "ruleId": "universalizing-claims",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 62488,
+        "line": 1523,
+        "loc": {
+          "end": {
+            "column": 66,
+            "line": 1523
+          },
+          "start": {
+            "column": 1,
+            "line": 1523
+          }
+        },
+        "message": "Universalizing claim found: some of the biggest advances in technology emerged from failures. Replace the broad claim with a bounded claim.",
+        "range": [
+          62488,
+          62553
+        ],
+        "ruleId": "universalizing-claims",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 62555,
+        "line": 1525,
+        "loc": {
+          "end": {
+            "column": 61,
+            "line": 1525
+          },
+          "start": {
+            "column": 1,
+            "line": 1525
+          }
+        },
+        "message": "Universalizing claim found: some of the deepest lessons in growth started with setbacks. Replace the broad claim with a bounded claim.",
+        "range": [
+          62555,
+          62615
+        ],
+        "ruleId": "universalizing-claims",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 62617,
+        "line": 1527,
+        "loc": {
+          "end": {
+            "column": 70,
+            "line": 1527
+          },
+          "start": {
+            "column": 1,
+            "line": 1527
+          }
+        },
+        "message": "Universalizing claim found: many of the most important ideas in management began with discomfort. Replace the broad claim with a bounded claim.",
+        "range": [
+          62617,
+          62686
+        ],
+        "ruleId": "universalizing-claims",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 62688,
+        "line": 1529,
+        "loc": {
+          "end": {
+            "column": 57,
+            "line": 1529
+          },
+          "start": {
+            "column": 1,
+            "line": 1529
+          }
+        },
+        "message": "Universalizing claim found: some of the greatest shifts in work come from elsewhere. Replace the broad claim with a bounded claim.",
+        "range": [
+          62688,
+          62744
+        ],
+        "ruleId": "universalizing-claims",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 62746,
+        "line": 1531,
+        "loc": {
+          "end": {
+            "column": 58,
+            "line": 1531
+          },
+          "start": {
+            "column": 1,
+            "line": 1531
+          }
+        },
+        "message": "Universalizing claim found: many of the biggest changes in life grow from challenges. Replace the broad claim with a bounded claim.",
+        "range": [
+          62746,
+          62803
+        ],
+        "ruleId": "universalizing-claims",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 62805,
+        "line": 1533,
+        "loc": {
+          "end": {
+            "column": 69,
+            "line": 1533
+          },
+          "start": {
+            "column": 1,
+            "line": 1533
+          }
+        },
+        "message": "Universalizing claim found: some of the most valuable breakthroughs come from unexpected places. Replace the broad claim with a bounded claim.",
+        "range": [
+          62805,
+          62873
+        ],
+        "ruleId": "universalizing-claims",
+        "severity": 2,
+        "type": "lint"
       }
     ]
   },
@@ -17639,7 +18053,7 @@
             "line": 1
           }
         },
-        "message": "Flesch Reading Ease is 46.95. Keep it at 61 or higher.",
+        "message": "Flesch Reading Ease is 44.82. Keep it at 61 or higher.",
         "range": [
           0,
           1
@@ -17662,7 +18076,7 @@
             "line": 1
           }
         },
-        "message": "Gunning Fog is 15.59. Keep it at 12 or lower.",
+        "message": "Gunning Fog is 16.39. Keep it at 12 or lower.",
         "range": [
           0,
           1

--- a/behavior/golden/textlint-rules-corpus-engineering-review/approved.meta.json
+++ b/behavior/golden/textlint-rules-corpus-engineering-review/approved.meta.json
@@ -1,18 +1,19 @@
 {
   "suite": "textlint-rules-corpus-engineering-review",
   "kind": "approved",
-  "run_id": "2026-07-24T22-37-14.896267Z-04547efb",
-  "run_commit": "ac067f7",
+  "run_id": "2026-07-28T11-42-35.387258Z-04547efb",
+  "run_commit": "4d6c658",
   "working_tree": "dirty",
-  "recorded_at": "2026-07-24T22:37:14.896267Z",
-  "fixture_hash": "sha256:07c79aa909b728907c7ea1c6bf649c45b0ea14d74695abc7a9ff732b0f237867",
+  "recorded_at": "2026-07-28T11:42:35.387258Z",
+  "fixture_hash": "sha256:df6c1f7d66f74176c0fb042701031a3cbe9b7d9de718cc3ce097593f8b3c9745",
   "manifest_hash": "sha256:04547efbb13157ee3d8ef18dda767231fd63d3f9cc27c15317cf28c5f0583e7b",
   "tool_version": "0.1.8",
   "output_schema_version": "1",
   "fixtures": [
     {
       "path": "behavior/fixtures/textlint-rules/corpus/engineering-review.md",
-      "sha256": "sha256:5736692e976b2d333ea07e9662ea66bf241c8057022e46b2318fca559b7dee43"
+      "sha256": "sha256:3ff41a6cbfdf72e506385a87a12438fd0b2bc099f5a623527c4e1a388bfc651d"
     }
-  ]
+  ],
+  "comment": "Integrate preserved claim cases into short topic paragraphs."
 }

--- a/behavior/golden/textlint-rules-corpus-engineering-review/approved.normalized.json
+++ b/behavior/golden/textlint-rules-corpus-engineering-review/approved.normalized.json
@@ -16,7 +16,7 @@
             "line": 3
           }
         },
-        "message": "Flesch Reading Ease is 57.5. Keep it at 61 or higher.",
+        "message": "Flesch Reading Ease is 58.72. Keep it at 61 or higher.",
         "range": [
           28,
           29
@@ -4398,7 +4398,7 @@
       {
         "column": 72,
         "data": {
-          "message": "\"quietly\" used 12 times (1.3 per 1,000 words), above the 1-per-1,000-word warning threshold. Cut the filler uses; keep at most about one per 1,000 words.",
+          "message": "\"quietly\" used 12 times (1.2 per 1,000 words), above the 1-per-1,000-word warning threshold. Cut the filler uses; keep at most about one per 1,000 words.",
           "padding": {
             "isAbsolute": false,
             "range": [
@@ -4421,7 +4421,7 @@
             "line": 475
           }
         },
-        "message": "\"quietly\" used 12 times (1.3 per 1,000 words), above the 1-per-1,000-word warning threshold. Cut the filler uses; keep at most about one per 1,000 words.",
+        "message": "\"quietly\" used 12 times (1.2 per 1,000 words), above the 1-per-1,000-word warning threshold. Cut the filler uses; keep at most about one per 1,000 words.",
         "range": [
           19314,
           19321
@@ -11755,6 +11755,788 @@
           54796
         ],
         "ruleId": "flat-action-cadence",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 92,
+        "index": 55478,
+        "line": 1159,
+        "loc": {
+          "end": {
+            "column": 122,
+            "line": 1159
+          },
+          "start": {
+            "column": 92,
+            "line": 1159
+          }
+        },
+        "message": "Semantic thinness (hollow-significance): Catch lines that assert importance, sticking power, or consequence without naming a concrete referent or result. Matched template: {totalImpactSubject} {totalImpactVerb} {totalImpactObject}.",
+        "range": [
+          55478,
+          55508
+        ],
+        "ruleId": "semantic-thinness",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 92,
+        "index": 55478,
+        "line": 1159,
+        "loc": {
+          "end": {
+            "column": 187,
+            "line": 1159
+          },
+          "start": {
+            "column": 92,
+            "line": 1159
+          }
+        },
+        "message": "Flat action cadence: 3 adjacent short simple sentences use subject-action beats (shift). Vary the rhythm or add causal/sensory development.",
+        "range": [
+          55478,
+          55573
+        ],
+        "ruleId": "flat-action-cadence",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 123,
+        "index": 55509,
+        "line": 1159,
+        "loc": {
+          "end": {
+            "column": 153,
+            "line": 1159
+          },
+          "start": {
+            "column": 123,
+            "line": 1159
+          }
+        },
+        "message": "Semantic thinness (hollow-significance): Catch lines that assert importance, sticking power, or consequence without naming a concrete referent or result. Matched template: {totalImpactSubject} {totalImpactVerb} {totalImpactObject}.",
+        "range": [
+          55509,
+          55539
+        ],
+        "ruleId": "semantic-thinness",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 154,
+        "index": 55540,
+        "line": 1159,
+        "loc": {
+          "end": {
+            "column": 187,
+            "line": 1159
+          },
+          "start": {
+            "column": 154,
+            "line": 1159
+          }
+        },
+        "message": "Semantic thinness (hollow-significance): Catch lines that assert importance, sticking power, or consequence without naming a concrete referent or result. Matched template: {totalImpactSubject} {totalImpactVerb} {totalImpactObject}.",
+        "range": [
+          55540,
+          55573
+        ],
+        "ruleId": "semantic-thinness",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 188,
+        "index": 55574,
+        "line": 1159,
+        "loc": {
+          "end": {
+            "column": 220,
+            "line": 1159
+          },
+          "start": {
+            "column": 188,
+            "line": 1159
+          }
+        },
+        "message": "Semantic thinness (hollow-significance): Catch lines that assert importance, sticking power, or consequence without naming a concrete referent or result. Matched template: {totalImpactSubject} {totalImpactVerb} {totalImpactObject}.",
+        "range": [
+          55574,
+          55606
+        ],
+        "ruleId": "semantic-thinness",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 63,
+        "index": 55670,
+        "line": 1161,
+        "loc": {
+          "end": {
+            "column": 103,
+            "line": 1161
+          },
+          "start": {
+            "column": 63,
+            "line": 1161
+          }
+        },
+        "message": "Semantic thinness (hollow-significance): Catch lines that assert importance, sticking power, or consequence without naming a concrete referent or result. Matched template: {totalImpactSubject} {totalImpactVerb} {totalImpactObject}.",
+        "range": [
+          55670,
+          55710
+        ],
+        "ruleId": "semantic-thinness",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 104,
+        "index": 55711,
+        "line": 1161,
+        "loc": {
+          "end": {
+            "column": 137,
+            "line": 1161
+          },
+          "start": {
+            "column": 104,
+            "line": 1161
+          }
+        },
+        "message": "Semantic thinness (hollow-significance): Catch lines that assert importance, sticking power, or consequence without naming a concrete referent or result. Matched template: {totalImpactSubject} {differenceVerb} all the difference.",
+        "range": [
+          55711,
+          55744
+        ],
+        "ruleId": "semantic-thinness",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 138,
+        "index": 55745,
+        "line": 1161,
+        "loc": {
+          "end": {
+            "column": 173,
+            "line": 1161
+          },
+          "start": {
+            "column": 138,
+            "line": 1161
+          }
+        },
+        "message": "Semantic thinness (hollow-significance): Catch lines that assert importance, sticking power, or consequence without naming a concrete referent or result. Matched template: {totalImpactSubject} {totalImpactVerb} {totalImpactObject}.",
+        "range": [
+          55745,
+          55780
+        ],
+        "ruleId": "semantic-thinness",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 174,
+        "index": 55781,
+        "line": 1161,
+        "loc": {
+          "end": {
+            "column": 209,
+            "line": 1161
+          },
+          "start": {
+            "column": 174,
+            "line": 1161
+          }
+        },
+        "message": "Semantic thinness (hollow-significance): Catch lines that assert importance, sticking power, or consequence without naming a concrete referent or result. Matched template: {totalImpactSubject} {totalImpactVerb} {totalImpactObject}.",
+        "range": [
+          55781,
+          55816
+        ],
+        "ruleId": "semantic-thinness",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 60,
+        "index": 55877,
+        "line": 1163,
+        "loc": {
+          "end": {
+            "column": 93,
+            "line": 1163
+          },
+          "start": {
+            "column": 60,
+            "line": 1163
+          }
+        },
+        "message": "Semantic thinness (hollow-significance): Catch lines that assert importance, sticking power, or consequence without naming a concrete referent or result. Matched template: {totalImpactSubject} {totalImpactVerb} {totalImpactObject}.",
+        "range": [
+          55877,
+          55910
+        ],
+        "ruleId": "semantic-thinness",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 94,
+        "index": 55911,
+        "line": 1163,
+        "loc": {
+          "end": {
+            "column": 130,
+            "line": 1163
+          },
+          "start": {
+            "column": 94,
+            "line": 1163
+          }
+        },
+        "message": "Semantic thinness (hollow-significance): Catch lines that assert importance, sticking power, or consequence without naming a concrete referent or result. Matched template: {totalImpactSubject} {totalImpactVerb} {totalImpactObject}.",
+        "range": [
+          55911,
+          55947
+        ],
+        "ruleId": "semantic-thinness",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 131,
+        "index": 55948,
+        "line": 1163,
+        "loc": {
+          "end": {
+            "column": 166,
+            "line": 1163
+          },
+          "start": {
+            "column": 131,
+            "line": 1163
+          }
+        },
+        "message": "Semantic thinness (hollow-significance): Catch lines that assert importance, sticking power, or consequence without naming a concrete referent or result. Matched template: {totalImpactSubject} {differenceVerb} all the difference.",
+        "range": [
+          55948,
+          55983
+        ],
+        "ruleId": "semantic-thinness",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 167,
+        "index": 55984,
+        "line": 1163,
+        "loc": {
+          "end": {
+            "column": 201,
+            "line": 1163
+          },
+          "start": {
+            "column": 167,
+            "line": 1163
+          }
+        },
+        "message": "Semantic thinness (hollow-significance): Catch lines that assert importance, sticking power, or consequence without naming a concrete referent or result. Matched template: {totalImpactSubject} {totalImpactVerb} {totalImpactObject}.",
+        "range": [
+          55984,
+          56018
+        ],
+        "ruleId": "semantic-thinness",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 63,
+        "index": 56082,
+        "line": 1165,
+        "loc": {
+          "end": {
+            "column": 219,
+            "line": 1165
+          },
+          "start": {
+            "column": 63,
+            "line": 1165
+          }
+        },
+        "message": "Repeated sentence starts: 3 nearby sentences start with the same frame (that shift).",
+        "range": [
+          56082,
+          56238
+        ],
+        "ruleId": "repeated-sentence-starts",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 81,
+        "index": 57107,
+        "line": 1173,
+        "loc": {
+          "end": {
+            "column": 157,
+            "line": 1173
+          },
+          "start": {
+            "column": 81,
+            "line": 1173
+          }
+        },
+        "message": "Universalizing claim found: some of the biggest shifts in leadership come from experiences outside work. Replace the broad claim with a bounded claim.",
+        "range": [
+          57107,
+          57183
+        ],
+        "ruleId": "universalizing-claims",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 158,
+        "index": 57184,
+        "line": 1173,
+        "loc": {
+          "end": {
+            "column": 217,
+            "line": 1173
+          },
+          "start": {
+            "column": 158,
+            "line": 1173
+          }
+        },
+        "message": "Universalizing claim found: some of the greatest lessons in business come from failure. Replace the broad claim with a bounded claim.",
+        "range": [
+          57184,
+          57243
+        ],
+        "ruleId": "universalizing-claims",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 218,
+        "index": 57244,
+        "line": 1173,
+        "loc": {
+          "end": {
+            "column": 283,
+            "line": 1173
+          },
+          "start": {
+            "column": 218,
+            "line": 1173
+          }
+        },
+        "message": "Universalizing claim found: many of the deepest insights in leadership emerge from adversity. Replace the broad claim with a bounded claim.",
+        "range": [
+          57244,
+          57309
+        ],
+        "ruleId": "universalizing-claims",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 57,
+        "index": 57367,
+        "line": 1175,
+        "loc": {
+          "end": {
+            "column": 118,
+            "line": 1175
+          },
+          "start": {
+            "column": 57,
+            "line": 1175
+          }
+        },
+        "message": "Universalizing claim found: some of the best ideas in design come from unexpected places. Replace the broad claim with a bounded claim.",
+        "range": [
+          57367,
+          57428
+        ],
+        "ruleId": "universalizing-claims",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 119,
+        "index": 57429,
+        "line": 1175,
+        "loc": {
+          "end": {
+            "column": 181,
+            "line": 1175
+          },
+          "start": {
+            "column": 119,
+            "line": 1175
+          }
+        },
+        "message": "Universalizing claim found: some of the strongest skills in management grow from setbacks. Replace the broad claim with a bounded claim.",
+        "range": [
+          57429,
+          57491
+        ],
+        "ruleId": "universalizing-claims",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 182,
+        "index": 57492,
+        "line": 1175,
+        "loc": {
+          "end": {
+            "column": 245,
+            "line": 1175
+          },
+          "start": {
+            "column": 182,
+            "line": 1175
+          }
+        },
+        "message": "Universalizing claim found: many of the most valuable lessons in life come from discomfort. Replace the broad claim with a bounded claim.",
+        "range": [
+          57492,
+          57555
+        ],
+        "ruleId": "universalizing-claims",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 71,
+        "index": 57627,
+        "line": 1177,
+        "loc": {
+          "end": {
+            "column": 137,
+            "line": 1177
+          },
+          "start": {
+            "column": 71,
+            "line": 1177
+          }
+        },
+        "message": "Universalizing claim found: some of the most meaningful changes in careers start with failure. Replace the broad claim with a bounded claim.",
+        "range": [
+          57627,
+          57693
+        ],
+        "ruleId": "universalizing-claims",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 138,
+        "index": 57694,
+        "line": 1177,
+        "loc": {
+          "end": {
+            "column": 209,
+            "line": 1177
+          },
+          "start": {
+            "column": 138,
+            "line": 1177
+          }
+        },
+        "message": "Universalizing claim found: some of the biggest breakthroughs in technology emerge from challenges. Replace the broad claim with a bounded claim.",
+        "range": [
+          57694,
+          57765
+        ],
+        "ruleId": "universalizing-claims",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 210,
+        "index": 57766,
+        "line": 1177,
+        "loc": {
+          "end": {
+            "column": 281,
+            "line": 1177
+          },
+          "start": {
+            "column": 210,
+            "line": 1177
+          }
+        },
+        "message": "Universalizing claim found: many of the most useful insights in writing come from ordinary moments. Replace the broad claim with a bounded claim.",
+        "range": [
+          57766,
+          57837
+        ],
+        "ruleId": "universalizing-claims",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 45,
+        "index": 57883,
+        "line": 1179,
+        "loc": {
+          "end": {
+            "column": 112,
+            "line": 1179
+          },
+          "start": {
+            "column": 45,
+            "line": 1179
+          }
+        },
+        "message": "Universalizing claim found: some of the greatest improvements in strategy begin with adversity. Replace the broad claim with a bounded claim.",
+        "range": [
+          57883,
+          57950
+        ],
+        "ruleId": "universalizing-claims",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 113,
+        "index": 57951,
+        "line": 1179,
+        "loc": {
+          "end": {
+            "column": 173,
+            "line": 1179
+          },
+          "start": {
+            "column": 113,
+            "line": 1179
+          }
+        },
+        "message": "Universalizing claim found: some of the best decisions in business came from experience. Replace the broad claim with a bounded claim.",
+        "range": [
+          57951,
+          58011
+        ],
+        "ruleId": "universalizing-claims",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 174,
+        "index": 58012,
+        "line": 1179,
+        "loc": {
+          "end": {
+            "column": 252,
+            "line": 1179
+          },
+          "start": {
+            "column": 174,
+            "line": 1179
+          }
+        },
+        "message": "Universalizing claim found: many of the strongest skills in leadership grew from experiences outside work. Replace the broad claim with a bounded claim.",
+        "range": [
+          58012,
+          58090
+        ],
+        "ruleId": "universalizing-claims",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 49,
+        "index": 58140,
+        "line": 1181,
+        "loc": {
+          "end": {
+            "column": 114,
+            "line": 1181
+          },
+          "start": {
+            "column": 49,
+            "line": 1181
+          }
+        },
+        "message": "Universalizing claim found: some of the biggest advances in technology emerged from failures. Replace the broad claim with a bounded claim.",
+        "range": [
+          58140,
+          58205
+        ],
+        "ruleId": "universalizing-claims",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 115,
+        "index": 58206,
+        "line": 1181,
+        "loc": {
+          "end": {
+            "column": 175,
+            "line": 1181
+          },
+          "start": {
+            "column": 115,
+            "line": 1181
+          }
+        },
+        "message": "Universalizing claim found: some of the deepest lessons in growth started with setbacks. Replace the broad claim with a bounded claim.",
+        "range": [
+          58206,
+          58266
+        ],
+        "ruleId": "universalizing-claims",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 176,
+        "index": 58267,
+        "line": 1181,
+        "loc": {
+          "end": {
+            "column": 245,
+            "line": 1181
+          },
+          "start": {
+            "column": 176,
+            "line": 1181
+          }
+        },
+        "message": "Universalizing claim found: many of the most important ideas in management began with discomfort. Replace the broad claim with a bounded claim.",
+        "range": [
+          58267,
+          58336
+        ],
+        "ruleId": "universalizing-claims",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 91,
+        "index": 58428,
+        "line": 1183,
+        "loc": {
+          "end": {
+            "column": 147,
+            "line": 1183
+          },
+          "start": {
+            "column": 91,
+            "line": 1183
+          }
+        },
+        "message": "Universalizing claim found: some of the greatest shifts in work come from elsewhere. Replace the broad claim with a bounded claim.",
+        "range": [
+          58428,
+          58484
+        ],
+        "ruleId": "universalizing-claims",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 148,
+        "index": 58485,
+        "line": 1183,
+        "loc": {
+          "end": {
+            "column": 205,
+            "line": 1183
+          },
+          "start": {
+            "column": 148,
+            "line": 1183
+          }
+        },
+        "message": "Universalizing claim found: many of the biggest changes in life grow from challenges. Replace the broad claim with a bounded claim.",
+        "range": [
+          58485,
+          58542
+        ],
+        "ruleId": "universalizing-claims",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 206,
+        "index": 58543,
+        "line": 1183,
+        "loc": {
+          "end": {
+            "column": 274,
+            "line": 1183
+          },
+          "start": {
+            "column": 206,
+            "line": 1183
+          }
+        },
+        "message": "Universalizing claim found: some of the most valuable breakthroughs come from unexpected places. Replace the broad claim with a bounded claim.",
+        "range": [
+          58543,
+          58611
+        ],
+        "ruleId": "universalizing-claims",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 46,
+        "index": 58944,
+        "line": 1187,
+        "loc": {
+          "end": {
+            "column": 190,
+            "line": 1187
+          },
+          "start": {
+            "column": 46,
+            "line": 1187
+          }
+        },
+        "message": "Repeated sentence starts: 3 nearby sentences start with the same frame (some of).",
+        "range": [
+          58944,
+          59088
+        ],
+        "ruleId": "repeated-sentence-starts",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 58,
+        "index": 59986,
+        "line": 1195,
+        "loc": {
+          "end": {
+            "column": 286,
+            "line": 1195
+          },
+          "start": {
+            "column": 58,
+            "line": 1195
+          }
+        },
+        "message": "Repeated sentence starts: 3 nearby sentences start with the same frame (some of).",
+        "range": [
+          59986,
+          60214
+        ],
+        "ruleId": "repeated-sentence-starts",
         "severity": 2,
         "type": "lint"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "slopless",
-  "version": "0.2.31",
+  "version": "0.2.32",
   "description": "Deterministic textlint rules and CLI for catching prose slop in English Markdown.",
   "keywords": [
     "textlint",

--- a/src/rules/semantic-thinness/patterns/hollow-significance.json
+++ b/src/rules/semantic-thinness/patterns/hollow-significance.json
@@ -16,7 +16,15 @@
     "{abstractSubject} now has {abstractPlural}, and the {abstractPlural} can {weakVerb}.",
     "{abstractSubject} still has work to do.",
     "{summarySubject} {linkingVerb} the part that {stickVerb}.",
-    "{deicticSubject} {changePhrase}."
+    "{deicticSubject} {changePhrase}.",
+    {
+      "text": "{totalImpactSubject} {totalImpactVerb} {totalImpactObject}.",
+      "matchMode": "full"
+    },
+    {
+      "text": "{totalImpactSubject} {differenceVerb} all the difference.",
+      "matchMode": "full"
+    }
   ],
   "slots": {
     "deicticSubject": [
@@ -159,6 +167,36 @@
       "mattered more than it seemed",
       "stuck with them"
     ],
+    "totalImpactSubject": [
+      "this shift",
+      "that shift",
+      "the shift",
+      "this change",
+      "that change",
+      "the change",
+      "this decision",
+      "that decision",
+      "the decision",
+      "this move",
+      "that move",
+      "the move",
+      "this experience",
+      "that experience",
+      "the experience",
+      "this result",
+      "that result",
+      "the result"
+    ],
+    "totalImpactVerb": [
+      "changed",
+      "changes",
+      "transformed",
+      "transforms",
+      "reshaped",
+      "reshapes"
+    ],
+    "totalImpactObject": ["everything", "the whole picture"],
+    "differenceVerb": ["made", "makes"],
     "intensifier": [
       "more than it seemed",
       "more than expected",

--- a/src/rules/syntactic-patterns/generalization/universalizing-claims.ts
+++ b/src/rules/syntactic-patterns/generalization/universalizing-claims.ts
@@ -92,6 +92,127 @@ const GROUP_BEHAVIOR_GERUNDS = [
   "wondering"
 ];
 const BROAD_GROUP_LEADS = ["many", "most"];
+const IMPORTANCE_QUALIFIERS = [
+  ["most", "important"],
+  ["most", "meaningful"],
+  ["most", "useful"],
+  ["most", "valuable"],
+  ["biggest"],
+  ["best"],
+  ["deepest"],
+  ["greatest"],
+  ["strongest"]
+] as const;
+const ABSTRACT_OUTCOMES = [
+  "advances",
+  "breakthroughs",
+  "changes",
+  "decisions",
+  "ideas",
+  "improvements",
+  "insights",
+  "lessons",
+  "shifts",
+  "skills"
+];
+const ABSTRACT_DOMAINS = [
+  "business",
+  "careers",
+  "design",
+  "growth",
+  "leadership",
+  "life",
+  "management",
+  "strategy",
+  "technology",
+  "work",
+  "writing"
+];
+const SOURCE_PREDICATES = [
+  ["come", "from"],
+  ["came", "from"],
+  ["grow", "from"],
+  ["grew", "from"],
+  ["emerge", "from"],
+  ["emerged", "from"],
+  ["start", "with"],
+  ["started", "with"],
+  ["begin", "with"],
+  ["began", "with"]
+] as const;
+const VAGUE_SOURCES = [
+  ["experiences", "outside", "work"],
+  ["unexpected", "places"],
+  ["ordinary", "moments"],
+  ["adversity"],
+  ["challenge"],
+  ["challenges"],
+  ["discomfort"],
+  ["elsewhere"],
+  ["experience"],
+  ["experiences"],
+  ["failure"],
+  ["failures"],
+  ["setback"],
+  ["setbacks"]
+] as const;
+
+function phraseLengthAt(
+  words: readonly string[],
+  index: number,
+  phrases: readonly (readonly string[])[]
+): number | undefined {
+  for (const phrase of phrases) {
+    if (startsWithWords(words.slice(index), phrase)) {
+      return phrase.length;
+    }
+  }
+
+  return undefined;
+}
+
+function matchVagueSuperlativeSource(
+  words: readonly string[]
+): string | undefined {
+  if (words[0] !== "some" && words[0] !== "many") {
+    return undefined;
+  }
+  if (words[1] !== "of" || words[2] !== "the") {
+    return undefined;
+  }
+
+  let index = 3;
+  const qualifierLength = phraseLengthAt(words, index, IMPORTANCE_QUALIFIERS);
+  if (qualifierLength === undefined) {
+    return undefined;
+  }
+  index += qualifierLength;
+
+  if (!ABSTRACT_OUTCOMES.includes(words[index] ?? "")) {
+    return undefined;
+  }
+  index += 1;
+
+  if (words[index] === "in") {
+    if (!ABSTRACT_DOMAINS.includes(words[index + 1] ?? "")) {
+      return undefined;
+    }
+    index += 2;
+  }
+
+  const predicateLength = phraseLengthAt(words, index, SOURCE_PREDICATES);
+  if (predicateLength === undefined) {
+    return undefined;
+  }
+  index += predicateLength;
+
+  const sourceLength = phraseLengthAt(words, index, VAGUE_SOURCES);
+  if (sourceLength === undefined || index + sourceLength !== words.length) {
+    return undefined;
+  }
+
+  return words.join(" ");
+}
 
 function matchGroupBehavior(words: readonly string[]): string | undefined {
   const [first, subject, third, gerund] = words;
@@ -114,6 +235,11 @@ function matchGroupBehavior(words: readonly string[]): string | undefined {
 function matchUniversalizing(sentence: string): string | undefined {
   const cleaned = cleanSentence(sentence, PREFIXES);
   const words = tokens(cleaned);
+  const vagueSource = matchVagueSuperlativeSource(words);
+  if (vagueSource !== undefined) {
+    return vagueSource;
+  }
+
   const group = matchGroupBehavior(words);
 
   if (group !== undefined) {


### PR DESCRIPTION
## Summary
- extend hollow-significance with full-sentence total-impact templates
- extend universalizing-claims with vague superlative-source frames
- add 30 hits, 30 controls, flowing corpus coverage, and reviewed approvals

## Verification
- specular lint and verify
- pnpm run validate
- fixture3 check --all
- packed CLI install catches both reported examples