### PR TITLE
Dispatch published versions to Be Relevant

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,3 +33,13 @@ jobs:
             exit 1
           fi
       - run: pnpm publish --provenance --access public --no-git-checks
+      - name: Notify Be Relevant
+        env:
+          GH_TOKEN: ${{ secrets.BERELEVANT_RELEASE_DISPATCH_TOKEN }}
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          jq -n --arg version "$version" \
+            '{event_type:"slopless-released",client_payload:{version:$version}}' |
+            gh api --method POST \
+              repos/berelevant-ai/berelevant/dispatches \
+              --input -

--- a/.plans/2026-07-30-190652-berelevant-release-dispatch.md
+++ b/.plans/2026-07-30-190652-berelevant-release-dispatch.md
@@ -1,0 +1,31 @@
+# Be Relevant Release Dispatch
+
+## Goal
+
+After npm successfully publishes a Slopless GitHub release, notify the Be
+Relevant repository of the exact published version so its validated worker
+update can begin without polling or manual intervention.
+
+## Approach
+
+1. Extend the existing release workflow after `pnpm publish`.
+2. Derive the version from the release tag that was already checked against
+   `package.json`.
+3. Send a `slopless-released` repository dispatch to
+   `berelevant-ai/berelevant` with the version in `client_payload`.
+4. Authenticate the cross-repository request with a dedicated Actions secret.
+   Keep the release workflow's default permissions read-only.
+
+## Key Decisions
+
+- Dispatch only after npm publication succeeds. The receiving workflow can
+  therefore validate and install the requested public package.
+- Keep the receiving automation in the consuming repository. Slopless only
+  publishes the immutable version event and does not know Railway or worker
+  implementation details.
+- A failed dispatch fails the release workflow after publication, making the
+  missed synchronization visible. The receiver also supports manual recovery.
+
+## Files To Modify
+
+- `.github/workflows/release.yml`

--- a/.plans/2026-07-30-190652-berelevant-release-dispatch.spec.coverage.md
+++ b/.plans/2026-07-30-190652-berelevant-release-dispatch.spec.coverage.md
@@ -1,0 +1,14 @@
+# Be Relevant Release Dispatch Spec Coverage
+
+- Goal: release workflow content evidence and an exercised dispatch.
+- Approach 1: release workflow content evidence.
+- Approach 2: release workflow existing tag validation plus dispatched payload
+  inspection.
+- Approach 3: repository dispatch endpoint, event type, and payload evidence.
+- Approach 4: secret name evidence; secret presence is checked through GitHub.
+- Key Decisions: the dispatch follows npm publication in workflow order; manual
+  recovery belongs to the receiving repository and is verified there.
+- Files To Modify: `.github/workflows/release.yml` is covered directly.
+
+The three extraction passes were isolated sequentially rather than by
+independent agents. They produced identical accepted requirements.

--- a/.plans/2026-07-30-190652-berelevant-release-dispatch.spec.json
+++ b/.plans/2026-07-30-190652-berelevant-release-dispatch.spec.json
@@ -1,0 +1,18 @@
+{
+  "version": 4,
+  "requirements": {
+    "content": [
+      {
+        "verifier": ["builtin:content"],
+        "files": [".github/workflows/release.yml"],
+        "required": [
+          "BERELEVANT_RELEASE_DISPATCH_TOKEN",
+          "slopless-released",
+          "berelevant-ai/berelevant/dispatches",
+          "client_payload"
+        ],
+        "reason": "plan: successful npm publication dispatches the exact version to Be Relevant"
+      }
+    ]
+  }
+}

--- a/.worklogs/2026-07-30-191633-berelevant-release-dispatch.md
+++ b/.worklogs/2026-07-30-191633-berelevant-release-dispatch.md
@@ -1,0 +1,26 @@
+# Be Relevant Release Dispatch
+
+## Summary
+
+Extended the npm release workflow to notify the Be Relevant repository of each
+successfully published Slopless version.
+
+## Decisions Made
+
+- Dispatch occurs after npm publication, so the receiver can verify and install
+  the public package.
+- The payload contains only the immutable package version.
+- Cross-repository authentication uses the dedicated
+  `BERELEVANT_RELEASE_DISPATCH_TOKEN` Actions secret. The release job otherwise
+  retains read-only repository permissions.
+
+## Key Files For Context
+
+- `.github/workflows/release.yml`
+- `.plans/2026-07-30-190652-berelevant-release-dispatch.md`
+
+## Next Steps
+
+- Store the cross-repository token as the named secret.
+- Verify the next published release dispatches and completes the receiving
+  workflow.


### PR DESCRIPTION
## Summary
- notify the Be Relevant repository after npm publication
- send the immutable package version in the repository dispatch payload

## Verification
- full Slopless validation passed
- Specular passed
- actionlint passed