### PR TITLE
Catch adverb-separated negation reframes

### DIFF
--- a/.plans/2026-08-10-221109-copular-negation-adverbs.md
+++ b/.plans/2026-08-10-221109-copular-negation-adverbs.md
@@ -1,0 +1,29 @@
+# Copular negation adverbs
+
+## Goal
+
+Detect staged sentence-pair reframes when an existing optional adverb separates a linking verb from `not`, including `The harder part is usually not counting products. It is resolving how many different rules produce and distribute their data.` Keep ownership in `syntactic-patterns:negation-reframe` and preserve current behavior for plain descriptions and factual negation.
+
+## Approach
+
+1. Update `findCopularNegation` in `src/rules/syntactic-patterns/contrast/private/negation-reframe-parts.ts` to skip the existing `OPTIONAL_ADVERBS` immediately after an uncontracted linking verb before checking for `not`. Return the predicate position after `not`, as the direct `is not` path does now.
+2. Do not add a phrase, subject-noun list, rule, family, or reporting policy. The existing sentence-pair matcher, subject handling, and factual-evidence classification remain responsible for deciding whether the parsed negation is a reportable reframe.
+3. Add isolated hit cases for `usually`, `really`, and `necessarily` between the linking verb and `not`. Add no-hit cases for a positive sentence, a standalone negated sentence, and a negated sentence followed by a concrete factual sentence rather than an `It is Y` replacement.
+4. Add the reviewed cases to `engineering-review.md` as a cohesive passage and register each exact case in its preserve file.
+5. Run Specular, Fixture3 for the syntactic cases and engineering corpus, the complete Fixture3 set, corpus preservation, and package validation. Review every changed finding before approval.
+
+## Key decisions
+
+- Fix parsing at `findCopularNegation`. Adding `The harder part` to generic-signposting would detect one wrapper while leaving the broken `is usually not` syntax elsewhere.
+- Reuse `OPTIONAL_ADVERBS`. A second list for the same grammatical position would create inconsistent parsing.
+- Keep evidence filtering unchanged until Fixture3 output demonstrates a concrete classification problem. The supplied miss occurs before classification.
+- Report the complete two-sentence span through the existing `negation-reframe` rule.
+
+## Files to modify
+
+- `src/rules/syntactic-patterns/contrast/private/negation-reframe-parts.ts`
+- `behavior/fixtures/textlint-rules/cases/syntactic-patterns/hits.md`
+- `behavior/fixtures/textlint-rules/cases/syntactic-patterns/no-hits.md`
+- `behavior/fixtures/textlint-rules/corpus/engineering-review.md`
+- `behavior/fixtures/textlint-rules/corpus/engineering-review.preserve.json`
+- Fixture3 approved output changed by the reviewed findings

--- a/.plans/2026-08-10-221109-copular-negation-adverbs.spec.coverage.md
+++ b/.plans/2026-08-10-221109-copular-negation-adverbs.spec.coverage.md
@@ -1,0 +1,6 @@
+# Coverage map
+
+- Goal: `content` checks for the parser change, supplied hit case, corpus copy, and factual no-hit; `fixture3` checks reporting behavior and regressions.
+- Approach: parser and fixture changes map to the four `content` blocks; output review maps to `fixture3`; package checks map to mechanical verification.
+- Key decisions: `content` confirms reuse of `skipOptionalAdverbs`; code review confirms no new rule, vocabulary list, or reporting policy; `fixture3` confirms existing rule ownership.
+- Files to modify: the parser, cases, and corpus map to `content`; preserve metadata and approved output map to corpus-preserve verification and `fixture3`.

--- a/.plans/2026-08-10-221109-copular-negation-adverbs.spec.json
+++ b/.plans/2026-08-10-221109-copular-negation-adverbs.spec.json
@@ -1,0 +1,31 @@
+{
+  "version": 4,
+  "requirements": {
+    "content": [
+      {
+        "verifier": ["builtin:content"],
+        "files": ["src/rules/syntactic-patterns/contrast/private/negation-reframe-parts.ts"],
+        "exists": ["skipOptionalAdverbs(tokenWords, index + 1)"],
+        "reason": "Approach 1: uncontracted linking verbs skip the shared optional adverbs before checking for not"
+      },
+      {
+        "verifier": ["builtin:content"],
+        "files": ["behavior/fixtures/textlint-rules/cases/syntactic-patterns/hits.md"],
+        "exists": ["The harder part is usually not counting products. It is resolving how many different rules produce and distribute their data."],
+        "reason": "Approach 3: supplied behavior is an isolated hit case"
+      },
+      {
+        "verifier": ["builtin:content"],
+        "files": ["behavior/fixtures/textlint-rules/cases/syntactic-patterns/no-hits.md"],
+        "exists": ["The harder part is usually not counting products because the catalog defines bundles as one item."],
+        "reason": "Approach 3: a factual standalone negation remains a no-hit case"
+      },
+      {
+        "verifier": ["builtin:content"],
+        "files": ["behavior/fixtures/textlint-rules/corpus/engineering-review.md"],
+        "exists": ["The harder part is usually not counting products. It is resolving how many different rules produce and distribute their data."],
+        "reason": "Approach 4: supplied behavior is preserved in corpus prose"
+      }
+    ]
+  }
+}

--- a/.worklogs/2026-08-10-221955-copular-negation-adverbs.md
+++ b/.worklogs/2026-08-10-221955-copular-negation-adverbs.md
@@ -1,0 +1,26 @@
+# Copular negation adverbs
+
+## Summary
+
+Extended the existing negation parser to recognize optional adverbs between a linking verb and `not`. Added reviewed hit and no-hit cases plus matching corpus prose for the newly recognized sentence-pair reframes.
+
+## Decisions made
+
+- Fixed `findCopularNegation` instead of adding a literal `The harder part` pattern or a new rule.
+- Reused `OPTIONAL_ADVERBS`, which already controls equivalent optional positions elsewhere in negation matching.
+- Kept sentence-pair classification and evidence gates unchanged. Fixture3 showed the supplied sentence and two structural variants as hits while four factual and incomplete controls remained clean.
+- Approved exactly three new `negation-reframe` findings in cases and the same three in the engineering corpus. No other rule count changed.
+- Did not repair the global corpus-preserve verifier. Current `main` has hundreds of stale mappings from earlier releases; the seven entries added here are present in cases, corpus text, and preserve metadata.
+
+## Key files for context
+
+- `.plans/2026-08-10-221109-copular-negation-adverbs.md`
+- `src/rules/syntactic-patterns/contrast/private/negation-reframe-parts.ts`
+- `behavior/fixtures/textlint-rules/cases/syntactic-patterns/hits.md`
+- `behavior/fixtures/textlint-rules/cases/syntactic-patterns/no-hits.md`
+- `behavior/fixtures/textlint-rules/corpus/engineering-review.md`
+
+## Next steps
+
+- Merge after GitHub CI passes, publish the next patch version, and install it locally.
+- Repair stale corpus-preserve mappings as a separate repository-wide bookkeeping change.

--- a/behavior/fixtures/textlint-rules/cases/syntactic-patterns/hits.md
+++ b/behavior/fixtures/textlint-rules/cases/syntactic-patterns/hits.md
@@ -1683,3 +1683,9 @@ The reviewer would still inspect the diff. The owner would still approve the rel
 The cache may still contain stale entries. The worker may still read one. The response may still expose the old value.
 
 The model might still choose the wrong tool. The tool might still reject the call. The application might still record the attempt.
+
+The harder part is usually not counting products. It is resolving how many different rules produce and distribute their data.
+
+The difficult question is really not choosing a parser. It is deciding which malformed inputs the parser must reject.
+
+The useful work is actually not writing more checks. It is defining the boundary each check must enforce.

--- a/behavior/fixtures/textlint-rules/cases/syntactic-patterns/no-hits.md
+++ b/behavior/fixtures/textlint-rules/cases/syntactic-patterns/no-hits.md
@@ -768,3 +768,11 @@ Rule 4 says the service should still respond. Section 5 says the client should s
 The service remains still during calibration because its motor is locked. During client calibration, the carriage remains still under the clamp. A steel pin keeps the proxy arm still until the gauge reaches zero.
 
 The service should respond after failover. The client should retry once. The proxy should preserve the trace ID.
+
+The harder part is usually counting products after the nightly import.
+
+The harder part is usually not counting products because the catalog defines bundles as one item.
+
+The index is usually not available during the rebuild. The status page records the maintenance window.
+
+The index is usually not available when the nightly rebuild runs. It is restored by the deployment job at 04:00.

--- a/behavior/fixtures/textlint-rules/corpus/engineering-review.md
+++ b/behavior/fixtures/textlint-rules/corpus/engineering-review.md
@@ -1375,3 +1375,23 @@ The meticulous scribe copied every surviving line of the charter.
 The testament was admitted as evidence in the probate hearing.
 
 The valuable painting was insured for EUR 2 million.
+
+## Negation parser review
+
+The review separated staged reversals from plain descriptions.
+
+The harder part is usually not counting products. It is resolving how many different rules produce and distribute their data.
+
+The difficult question is really not choosing a parser. It is deciding which malformed inputs the parser must reject.
+
+The useful work is actually not writing more checks. It is defining the boundary each check must enforce.
+
+The controls retained concrete statements and explanations.
+
+The harder part is usually counting products after the nightly import.
+
+The harder part is usually not counting products because the catalog defines bundles as one item.
+
+The index is usually not available during the rebuild. The status page records the maintenance window.
+
+The index is usually not available when the nightly rebuild runs. It is restored by the deployment job at 04:00.

--- a/behavior/fixtures/textlint-rules/corpus/engineering-review.preserve.json
+++ b/behavior/fixtures/textlint-rules/corpus/engineering-review.preserve.json
@@ -5279,6 +5279,41 @@
       "bucket": "no-hits",
       "source": "cases/syntactic-patterns/no-hits.md",
       "line": 631
+    },
+    {
+      "text": "The harder part is usually not counting products. It is resolving how many different rules produce and distribute their data.",
+      "family": "syntactic-patterns",
+      "bucket": "hits"
+    },
+    {
+      "text": "The difficult question is really not choosing a parser. It is deciding which malformed inputs the parser must reject.",
+      "family": "syntactic-patterns",
+      "bucket": "hits"
+    },
+    {
+      "text": "The useful work is actually not writing more checks. It is defining the boundary each check must enforce.",
+      "family": "syntactic-patterns",
+      "bucket": "hits"
+    },
+    {
+      "text": "The harder part is usually counting products after the nightly import.",
+      "family": "syntactic-patterns",
+      "bucket": "no-hits"
+    },
+    {
+      "text": "The harder part is usually not counting products because the catalog defines bundles as one item.",
+      "family": "syntactic-patterns",
+      "bucket": "no-hits"
+    },
+    {
+      "text": "The index is usually not available during the rebuild. The status page records the maintenance window.",
+      "family": "syntactic-patterns",
+      "bucket": "no-hits"
+    },
+    {
+      "text": "The index is usually not available when the nightly rebuild runs. It is restored by the deployment job at 04:00.",
+      "family": "syntactic-patterns",
+      "bucket": "no-hits"
     }
   ]
 }

--- a/behavior/golden/textlint-rules-cases-syntactic-patterns/approved.meta.json
+++ b/behavior/golden/textlint-rules-cases-syntactic-patterns/approved.meta.json
@@ -1,27 +1,27 @@
 {
   "suite": "textlint-rules-cases-syntactic-patterns",
   "kind": "approved",
-  "run_id": "2026-08-05T14-29-51.640003Z-04547efb",
-  "run_commit": "738ba67",
+  "run_id": "2026-08-10T21-15-25.266767Z-b77b0da6",
+  "run_commit": "16396da",
   "working_tree": "dirty",
-  "recorded_at": "2026-08-05T14:29:51.640003Z",
-  "fixture_hash": "sha256:11bfe991e6360b88fd3c6e4ba9f4c9e49234b360a10b159ff7009955bf6b31b5",
-  "manifest_hash": "sha256:04547efbb13157ee3d8ef18dda767231fd63d3f9cc27c15317cf28c5f0583e7b",
+  "recorded_at": "2026-08-10T21:15:25.266767Z",
+  "fixture_hash": "sha256:339516b029bfff8f12bbadbf2612f5eb7f17b86bda8136f2da5d45bed6c408ea",
+  "manifest_hash": "sha256:b77b0da670219bad01853e28edd62603bed4bd31eb8f72add6dfa8feb7d3ddc1",
   "tool_version": "0.1.8",
   "output_schema_version": "1",
   "fixtures": [
     {
       "path": "behavior/fixtures/textlint-rules/cases/syntactic-patterns/hits.md",
-      "sha256": "sha256:e56fe742c14d6a8bb712e92fc0f208f7e48806cd984de563aa0df289fbe67852"
+      "sha256": "sha256:320b696106d341fca0f454ec138d4063c774a6163de9b969a13acef0c17736cf"
     },
     {
       "path": "behavior/fixtures/textlint-rules/cases/syntactic-patterns/no-hits.md",
-      "sha256": "sha256:4ea06fbfdc20689a1b1ffc3567a5dc2ba542344681d0b8c5bb0121e38ed3743b"
+      "sha256": "sha256:55cb1227c57cb3f196bdce1aa91e347e5b22098f4de2dd67dcf736c446ff0a45"
     },
     {
       "path": "behavior/fixtures/textlint-rules/cases/syntactic-patterns/significance-density.md",
       "sha256": "sha256:a5489177104e3714ea3558c1d90bdd91573bf719c83112225ae9e9b0e288c6da"
     }
   ],
-  "comment": "Add evaluative colon signposts and repeated modal-still frames; remove default readability findings"
+  "comment": "Recognize optional adverbs between linking verbs and not"
 }

--- a/behavior/golden/textlint-rules-cases-syntactic-patterns/approved.normalized.json
+++ b/behavior/golden/textlint-rules-cases-syntactic-patterns/approved.normalized.json
@@ -19850,6 +19850,75 @@
         "ruleId": "triple-sentence-repeat",
         "severity": 2,
         "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 69650,
+        "line": 1687,
+        "loc": {
+          "end": {
+            "column": 126,
+            "line": 1687
+          },
+          "start": {
+            "column": 1,
+            "line": 1687
+          }
+        },
+        "message": "Negation reframe found: \"The harder part is usually not counting products. It is resolving how many different rules produce and distribute their data.\". Rewrite the staged negation as a direct claim.",
+        "range": [
+          69650,
+          69775
+        ],
+        "ruleId": "negation-reframe",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 69777,
+        "line": 1689,
+        "loc": {
+          "end": {
+            "column": 118,
+            "line": 1689
+          },
+          "start": {
+            "column": 1,
+            "line": 1689
+          }
+        },
+        "message": "Negation reframe found: \"The difficult question is really not choosing a parser. It is deciding which malformed inputs the parser must reject.\". Rewrite the staged negation as a direct claim.",
+        "range": [
+          69777,
+          69894
+        ],
+        "ruleId": "negation-reframe",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 69896,
+        "line": 1691,
+        "loc": {
+          "end": {
+            "column": 106,
+            "line": 1691
+          },
+          "start": {
+            "column": 1,
+            "line": 1691
+          }
+        },
+        "message": "Negation reframe found: \"The useful work is actually not writing more checks. It is defining the boundary each check must enforce.\". Rewrite the staged negation as a direct claim.",
+        "range": [
+          69896,
+          70001
+        ],
+        "ruleId": "negation-reframe",
+        "severity": 2,
+        "type": "lint"
       }
     ]
   },
@@ -19893,7 +19962,7 @@
             "line": 1
           }
         },
-        "message": "Gunning Fog is 13.62. Keep it at 12 or lower.",
+        "message": "Gunning Fog is 13.6. Keep it at 12 or lower.",
         "range": [
           0,
           1

--- a/behavior/golden/textlint-rules-corpus-engineering-review/approved.meta.json
+++ b/behavior/golden/textlint-rules-corpus-engineering-review/approved.meta.json
@@ -1,19 +1,19 @@
 {
   "suite": "textlint-rules-corpus-engineering-review",
   "kind": "approved",
-  "run_id": "2026-08-05T13-08-51.681674Z-04547efb",
-  "run_commit": "e891d0d",
+  "run_id": "2026-08-10T21-15-55.311176Z-b77b0da6",
+  "run_commit": "16396da",
   "working_tree": "dirty",
-  "recorded_at": "2026-08-05T13:08:51.681674Z",
-  "fixture_hash": "sha256:f53031d5751bca39939025fea38c91a2977080b19123a487fab44874c318467c",
-  "manifest_hash": "sha256:04547efbb13157ee3d8ef18dda767231fd63d3f9cc27c15317cf28c5f0583e7b",
+  "recorded_at": "2026-08-10T21:15:55.311176Z",
+  "fixture_hash": "sha256:d0458b7c2b91dca1d551148222a06f7d6932ba7787176b76076018de3c07d3a3",
+  "manifest_hash": "sha256:b77b0da670219bad01853e28edd62603bed4bd31eb8f72add6dfa8feb7d3ddc1",
   "tool_version": "0.1.8",
   "output_schema_version": "1",
   "fixtures": [
     {
       "path": "behavior/fixtures/textlint-rules/corpus/engineering-review.md",
-      "sha256": "sha256:2995163b635df211249e00f7eab758e9aab17356fa91c8a41a4221296d6bef4d"
+      "sha256": "sha256:bae47707418ba9755c05e5fb8a79c5cac5485cb649e4818dac965caf672e1951"
     }
   ],
-  "comment": "Reviewed elliptical action-stack expansion and corrected sentence boundaries"
+  "comment": "Preserve optional-adverb negation reframes in corpus prose"
 }

--- a/behavior/golden/textlint-rules-corpus-engineering-review/approved.normalized.json
+++ b/behavior/golden/textlint-rules-corpus-engineering-review/approved.normalized.json
@@ -39,7 +39,7 @@
             "line": 3
           }
         },
-        "message": "Flesch Reading Ease is 48.43. Keep it at 61 or higher.",
+        "message": "Flesch Reading Ease is 48.33. Keep it at 61 or higher.",
         "range": [
           28,
           29
@@ -12583,6 +12583,75 @@
           60214
         ],
         "ruleId": "repeated-sentence-starts",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 66606,
+        "line": 1383,
+        "loc": {
+          "end": {
+            "column": 126,
+            "line": 1383
+          },
+          "start": {
+            "column": 1,
+            "line": 1383
+          }
+        },
+        "message": "Negation reframe found: \"The harder part is usually not counting products. It is resolving how many different rules produce and distribute their data.\". Rewrite the staged negation as a direct claim.",
+        "range": [
+          66606,
+          66731
+        ],
+        "ruleId": "negation-reframe",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 66733,
+        "line": 1385,
+        "loc": {
+          "end": {
+            "column": 118,
+            "line": 1385
+          },
+          "start": {
+            "column": 1,
+            "line": 1385
+          }
+        },
+        "message": "Negation reframe found: \"The difficult question is really not choosing a parser. It is deciding which malformed inputs the parser must reject.\". Rewrite the staged negation as a direct claim.",
+        "range": [
+          66733,
+          66850
+        ],
+        "ruleId": "negation-reframe",
+        "severity": 2,
+        "type": "lint"
+      },
+      {
+        "column": 1,
+        "index": 66852,
+        "line": 1387,
+        "loc": {
+          "end": {
+            "column": 106,
+            "line": 1387
+          },
+          "start": {
+            "column": 1,
+            "line": 1387
+          }
+        },
+        "message": "Negation reframe found: \"The useful work is actually not writing more checks. It is defining the boundary each check must enforce.\". Rewrite the staged negation as a direct claim.",
+        "range": [
+          66852,
+          66957
+        ],
+        "ruleId": "negation-reframe",
         "severity": 2,
         "type": "lint"
       }

--- a/src/rules/syntactic-patterns/contrast/private/negation-reframe-parts.ts
+++ b/src/rules/syntactic-patterns/contrast/private/negation-reframe-parts.ts
@@ -294,6 +294,7 @@ export function findCopularNegation(
     const next = tokenWords[index + 1];
     const explicitAux =
       current === undefined ? undefined : COPULAR_FORMS.get(current);
+    const negationIndex = skipOptionalAdverbs(tokenWords, index + 1);
 
     if (
       explicitAux !== undefined &&
@@ -308,10 +309,10 @@ export function findCopularNegation(
       };
     }
 
-    if (explicitAux !== undefined && next === "not") {
+    if (explicitAux !== undefined && tokenWords[negationIndex] === "not") {
       return {
         affirmativeAux: explicitAux,
-        negatedPredicateStart: index + 2,
+        negatedPredicateStart: negationIndex + 1,
         subject: tokenWords.slice(0, index)
       };
     }


### PR DESCRIPTION
## Summary
- recognize optional adverbs between linking verbs and `not`
- preserve existing negation classification and reporting
- add reviewed hit, no-hit, and corpus coverage

## Verification
- `pnpm run validate`
- `fixture3 check --all --json` (20 suites matched)
- `specular lint` and `specular verify`

## Known repository issue
- `developer-helpers/scripts/verify-corpus-preserve.py` already fails on `main` because earlier fixture additions left stale preserve mappings; this change adds valid mappings for all seven new cases.