### PR TITLE
Release Slopless 0.2.36

### DIFF
--- a/.plans/2026-08-10-222242-release-0.2.36.md
+++ b/.plans/2026-08-10-222242-release-0.2.36.md
@@ -1,0 +1,22 @@
+# Release Slopless 0.2.36
+
+## Goal
+
+Publish the merged optional-adverb negation reframe fix as `slopless@0.2.36`, verify GitHub CI and npm publication, then install and test the published CLI locally.
+
+## Approach
+
+1. Change `package.json` from `0.2.35` to `0.2.36`.
+2. Run package validation, all Fixture3 suites, Specular, and a packed-package smoke test.
+3. Merge the release pull request after GitHub checks pass.
+4. Publish GitHub release `v0.2.36`, wait for the release workflow, and verify npm reports version `0.2.36`.
+5. Install `slopless@0.2.36` globally and confirm it reports the supplied sentence through `negation-reframe`.
+
+## Key decisions
+
+- Use a patch version because the CLI and rule IDs remain compatible.
+- Publish only through the existing GitHub release workflow so npm provenance is retained.
+
+## Files to modify
+
+- `package.json`

--- a/.plans/2026-08-10-222242-release-0.2.36.spec.coverage.md
+++ b/.plans/2026-08-10-222242-release-0.2.36.spec.coverage.md
@@ -1,0 +1,6 @@
+# Coverage map
+
+- Goal: package version maps to `content`; publication and installed CLI checks map to external release verification.
+- Approach: version maps to `content`; validation, Fixture3, npm packing, GitHub release, npm publication, and local installation map to mechanical verification.
+- Key decisions: patch compatibility and workflow-only publication map to release review.
+- Files to modify: `package.json` maps to `content`.

--- a/.plans/2026-08-10-222242-release-0.2.36.spec.json
+++ b/.plans/2026-08-10-222242-release-0.2.36.spec.json
@@ -1,0 +1,13 @@
+{
+  "version": 4,
+  "requirements": {
+    "content": [
+      {
+        "verifier": ["builtin:content"],
+        "files": ["package.json"],
+        "exists": ["\"version\": \"0.2.36\""],
+        "reason": "Approach 1: package version is the release version"
+      }
+    ]
+  }
+}

--- a/.worklogs/2026-08-10-222806-release-0.2.36.md
+++ b/.worklogs/2026-08-10-222806-release-0.2.36.md
@@ -1,0 +1,23 @@
+# Release Slopless 0.2.36
+
+## Summary
+
+Prepared patch release 0.2.36 for the merged optional-adverb negation reframe fix. Verified the packed CLI reports the supplied sentence through `slopless/negation-reframe`.
+
+## Decisions made
+
+- Used a patch release because no public interface or rule ID changed.
+- Kept publication in the GitHub release workflow to retain npm provenance.
+- Investigated one transient empty-output failure in the packed-CLI Fixture3 suite. The runner succeeded when traced directly, passed in an isolated rerun, and passed again in a complete 20-suite rerun; no deterministic defect was found.
+
+## Key files for context
+
+- `.plans/2026-08-10-222242-release-0.2.36.md`
+- `package.json`
+- `.github/workflows/release.yml`
+- `scripts/cli-replay.sh`
+
+## Next steps
+
+- Merge the release pull request after GitHub checks pass.
+- Publish GitHub release `v0.2.36`, verify npm publication, and install the published CLI locally.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "slopless",
-  "version": "0.2.35",
+  "version": "0.2.36",
   "description": "Deterministic textlint rules and CLI for catching prose slop in English Markdown.",
   "keywords": [
     "textlint",


### PR DESCRIPTION
## Summary
- bump Slopless to 0.2.36
- publish the merged optional-adverb negation reframe fix

## Verification
- `pnpm run validate`
- `fixture3 check --all --json` (20 suites matched)
- packed 0.2.36 CLI reports the supplied sentence through `slopless/negation-reframe`
- `specular lint` and `specular verify`